### PR TITLE
Extend event parsing for messages and reactions

### DIFF
--- a/disagreement/client.py
+++ b/disagreement/client.py
@@ -448,11 +448,16 @@ class Client:
         # Map common function names to Discord event types
         # e.g., on_ready -> READY, on_message -> MESSAGE_CREATE
         if event_name.startswith("on_"):
-            discord_event_name = event_name[3:].upper()  # e.g., on_message -> MESSAGE
-            if discord_event_name == "MESSAGE":  # Common case
-                discord_event_name = "MESSAGE_CREATE"
-            # Add other mappings if needed, e.g. on_member_join -> GUILD_MEMBER_ADD
-
+            discord_event_name = event_name[3:].upper()
+            mapping = {
+                "MESSAGE": "MESSAGE_CREATE",
+                "MESSAGE_EDIT": "MESSAGE_UPDATE",
+                "MESSAGE_UPDATE": "MESSAGE_UPDATE",
+                "MESSAGE_DELETE": "MESSAGE_DELETE",
+                "REACTION_ADD": "MESSAGE_REACTION_ADD",
+                "REACTION_REMOVE": "MESSAGE_REACTION_REMOVE",
+            }
+            discord_event_name = mapping.get(discord_event_name, discord_event_name)
             self._event_dispatcher.register(discord_event_name, coro)
         else:
             # If not starting with "on_", assume it's the direct Discord event name (e.g. "TYPING_START")

--- a/disagreement/event_dispatcher.py
+++ b/disagreement/event_dispatcher.py
@@ -47,6 +47,10 @@ class EventDispatcher:
         # Pre-defined parsers for specific event types to convert raw data to models
         self._event_parsers: Dict[str, Callable[[Dict[str, Any]], Any]] = {
             "MESSAGE_CREATE": self._parse_message_create,
+            "MESSAGE_UPDATE": self._parse_message_update,
+            "MESSAGE_DELETE": self._parse_message_delete,
+            "MESSAGE_REACTION_ADD": self._parse_message_reaction,
+            "MESSAGE_REACTION_REMOVE": self._parse_message_reaction,
             "INTERACTION_CREATE": self._parse_interaction_create,
             "GUILD_CREATE": self._parse_guild_create,
             "CHANNEL_CREATE": self._parse_channel_create,
@@ -57,6 +61,21 @@ class EventDispatcher:
     def _parse_message_create(self, data: Dict[str, Any]) -> Message:
         """Parses raw MESSAGE_CREATE data into a Message object."""
         return self._client.parse_message(data)
+
+    def _parse_message_update(self, data: Dict[str, Any]) -> Message:
+        """Parses raw MESSAGE_UPDATE data into a Message object."""
+        return self._client.parse_message(data)
+
+    def _parse_message_delete(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        """Parses MESSAGE_DELETE and updates message cache."""
+        message_id = data.get("id")
+        if message_id:
+            self._client._messages.pop(message_id, None)
+        return data
+
+    def _parse_message_reaction(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        """Returns the raw reaction payload."""
+        return data
 
     def _parse_interaction_create(self, data: Dict[str, Any]) -> "Interaction":
         """Parses raw INTERACTION_CREATE data into an Interaction object."""


### PR DESCRIPTION
## Summary
- handle message update/delete and reaction add/remove in EventDispatcher
- map new event names in Client.event decorator

## Testing
- `pyright`
- `pylint --disable=all --enable=E,F disagreement/event_dispatcher.py disagreement/client.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847d092f718832398bdfc9072c32d25