### PR TITLE
Add Webhook model and update helpers

### DIFF
--- a/disagreement/http.py
+++ b/disagreement/http.py
@@ -20,7 +20,7 @@ from . import __version__  # For User-Agent
 
 if TYPE_CHECKING:
     from .client import Client
-    from .models import Message
+    from .models import Message, Webhook
     from .interactions import ApplicationCommand, InteractionResponsePayload, Snowflake
 
 # Discord API constants
@@ -309,6 +309,33 @@ class HTTPClient:
     async def get_channel(self, channel_id: str) -> Dict[str, Any]:
         """Fetches a channel by ID."""
         return await self.request("GET", f"/channels/{channel_id}")
+
+    async def create_webhook(
+        self, channel_id: "Snowflake", payload: Dict[str, Any]
+    ) -> "Webhook":
+        """Creates a webhook in the specified channel."""
+
+        data = await self.request(
+            "POST", f"/channels/{channel_id}/webhooks", payload=payload
+        )
+        from .models import Webhook
+
+        return Webhook(data)
+
+    async def edit_webhook(
+        self, webhook_id: "Snowflake", payload: Dict[str, Any]
+    ) -> "Webhook":
+        """Edits an existing webhook."""
+
+        data = await self.request("PATCH", f"/webhooks/{webhook_id}", payload=payload)
+        from .models import Webhook
+
+        return Webhook(data)
+
+    async def delete_webhook(self, webhook_id: "Snowflake") -> None:
+        """Deletes a webhook."""
+
+        await self.request("DELETE", f"/webhooks/{webhook_id}")
 
     async def get_user(self, user_id: "Snowflake") -> Dict[str, Any]:
         """Fetches a user object for a given user ID."""

--- a/disagreement/models.py
+++ b/disagreement/models.py
@@ -1090,6 +1090,28 @@ class PartialChannel:
         return f"<PartialChannel id='{self.id}' name='{self.name}' type='{type_name}'>"
 
 
+class Webhook:
+    """Represents a Discord Webhook."""
+
+    def __init__(
+        self, data: Dict[str, Any], client_instance: Optional["Client"] = None
+    ):
+        self._client: Optional["Client"] = client_instance
+        self.id: str = data["id"]
+        self.type: int = int(data.get("type", 1))
+        self.guild_id: Optional[str] = data.get("guild_id")
+        self.channel_id: Optional[str] = data.get("channel_id")
+        self.name: Optional[str] = data.get("name")
+        self.avatar: Optional[str] = data.get("avatar")
+        self.token: Optional[str] = data.get("token")
+        self.application_id: Optional[str] = data.get("application_id")
+        self.url: Optional[str] = data.get("url")
+        self.user: Optional[User] = User(data["user"]) if data.get("user") else None
+
+    def __repr__(self) -> str:
+        return f"<Webhook id='{self.id}' name='{self.name}'>"
+
+
 # --- Message Components ---
 
 

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -9,7 +9,7 @@ from disagreement.http import HTTPClient
 
 http = HTTPClient(token="TOKEN")
 payload = {"name": "My Webhook"}
-webhook_data = await http.create_webhook("123", payload)
+webhook = await http.create_webhook("123", payload)
 ```
 
 ## Edit a webhook
@@ -24,11 +24,10 @@ await http.edit_webhook("456", {"name": "Renamed"})
 await http.delete_webhook("456")
 ```
 
-The methods return the raw webhook JSON. You can construct a `Webhook` model if needed:
+The methods now return a `Webhook` object directly:
 
 ```python
 from disagreement.models import Webhook
 
-webhook = Webhook(webhook_data)
 print(webhook.id, webhook.name)
 ```


### PR DESCRIPTION
## Summary
- implement `Webhook` data model
- update HTTP client with webhook helpers returning `Webhook`
- add client helpers for webhooks and parse logic
- document new return type
- test webhook helper functions

## Testing
- `pyright`
- `pylint --disable=all --enable=E,F disagreement tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847d09ab1b08323b3ccb5a10c9fb063