### PR TITLE
Add attachment upload support

### DIFF
--- a/disagreement/client.py
+++ b/disagreement/client.py
@@ -830,6 +830,7 @@ class Client:
         components: Optional[List["ActionRow"]] = None,
         allowed_mentions: Optional[Dict[str, Any]] = None,
         message_reference: Optional[Dict[str, Any]] = None,
+        attachments: Optional[List[Any]] = None,
         flags: Optional[int] = None,
         view: Optional["View"] = None,
     ) -> "Message":
@@ -846,6 +847,7 @@ class Client:
             components (Optional[List[ActionRow]]): A list of ActionRow components to include.
             allowed_mentions (Optional[Dict[str, Any]]): Allowed mentions for the message.
             message_reference (Optional[Dict[str, Any]]): Message reference for replying.
+            attachments (Optional[List[Any]]): Attachments to include with the message.
             flags (Optional[int]): Message flags.
             view (Optional[View]): A view to send with the message.
 
@@ -897,6 +899,7 @@ class Client:
             components=components_payload,
             allowed_mentions=allowed_mentions,
             message_reference=message_reference,
+            attachments=attachments,
             flags=flags,
         )
 

--- a/disagreement/http.py
+++ b/disagreement/http.py
@@ -204,11 +204,20 @@ class HTTPClient:
         components: Optional[List[Dict[str, Any]]] = None,
         allowed_mentions: Optional[dict] = None,
         message_reference: Optional[Dict[str, Any]] = None,
+        attachments: Optional[List[Any]] = None,
         flags: Optional[int] = None,
     ) -> Dict[str, Any]:
         """Sends a message to a channel.
 
-        Returns the created message data as a dict.
+        Parameters
+        ----------
+        attachments:
+            A list of attachment payloads to include with the message.
+
+        Returns
+        -------
+        Dict[str, Any]
+            The created message data.
         """
         payload: Dict[str, Any] = {}
         if content is not None:  # Content is optional if embeds/components are present
@@ -221,6 +230,10 @@ class HTTPClient:
             payload["components"] = components
         if allowed_mentions:
             payload["allowed_mentions"] = allowed_mentions
+        if attachments is not None:
+            payload["attachments"] = [
+                a.to_dict() if hasattr(a, "to_dict") else a for a in attachments
+            ]
         if flags:
             payload["flags"] = flags
         if message_reference:

--- a/disagreement/models.py
+++ b/disagreement/models.py
@@ -72,6 +72,7 @@ class Message:
         timestamp (str): When this message was sent (ISO8601 timestamp).
         components (Optional[List[ActionRow]]): Structured components attached
             to the message if present.
+        attachments (List[Attachment]): Attachments included with the message.
     """
 
     def __init__(self, data: dict, client_instance: "Client"):
@@ -92,6 +93,9 @@ class Message:
             ]
         else:
             self.components = None
+        self.attachments: List[Attachment] = [
+            Attachment(a) for a in data.get("attachments", [])
+        ]
         # Add other fields as needed, e.g., attachments, embeds, reactions, etc.
         # self.mentions: List[User] = [User(u) for u in data.get("mentions", [])]
         # self.mention_roles: List[str] = data.get("mention_roles", [])

--- a/tests/test_send_files.py
+++ b/tests/test_send_files.py
@@ -1,0 +1,46 @@
+import pytest
+from unittest.mock import AsyncMock
+
+from disagreement.client import Client
+from disagreement.http import HTTPClient
+from disagreement.models import Attachment
+
+
+@pytest.mark.asyncio
+async def test_http_send_message_includes_attachments():
+    http = HTTPClient(token="t")
+    http.request = AsyncMock(
+        return_value={
+            "id": "1",
+            "channel_id": "c",
+            "author": {"id": "2", "username": "u", "discriminator": "0001"},
+            "content": "hi",
+            "timestamp": "t",
+        }
+    )
+    await http.send_message("c", "hi", attachments=[{"id": 1}])
+    http.request.assert_called_once_with(
+        "POST",
+        "/channels/c/messages",
+        payload={"content": "hi", "attachments": [{"id": 1}]},
+    )
+
+
+@pytest.mark.asyncio
+async def test_client_send_message_passes_attachments():
+    client = Client(token="t")
+    client._http.send_message = AsyncMock(
+        return_value={
+            "id": "1",
+            "channel_id": "c",
+            "author": {"id": "2", "username": "u", "discriminator": "0001"},
+            "content": "hi",
+            "timestamp": "t",
+            "attachments": [{"id": "1", "filename": "f.txt"}],
+        }
+    )
+    msg = await client.send_message("c", "hi", attachments=[{"id": "1"}])
+    client._http.send_message.assert_awaited_once()
+    kwargs = client._http.send_message.call_args.kwargs
+    assert kwargs["attachments"] == [{"id": "1"}]
+    assert isinstance(msg.attachments[0], Attachment)


### PR DESCRIPTION
## Summary
- support attachments in HTTP and Client send_message
- parse attachments in Message model
- test sending attachment metadata

## Testing
- `pylint --disable=all --enable=E,F disagreement tests/test_send_files.py`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847d0a3b91483239c8afb059c835701