### PR TITLE
Implement file uploads for send_message

### DIFF
--- a/disagreement/client.py
+++ b/disagreement/client.py
@@ -853,6 +853,7 @@ class Client:
         allowed_mentions: Optional[Dict[str, Any]] = None,
         message_reference: Optional[Dict[str, Any]] = None,
         attachments: Optional[List[Any]] = None,
+        files: Optional[List[Any]] = None,
         flags: Optional[int] = None,
         view: Optional["View"] = None,
     ) -> "Message":
@@ -870,6 +871,7 @@ class Client:
             allowed_mentions (Optional[Dict[str, Any]]): Allowed mentions for the message.
             message_reference (Optional[Dict[str, Any]]): Message reference for replying.
             attachments (Optional[List[Any]]): Attachments to include with the message.
+            files (Optional[List[Any]]): Files to upload with the message.
             flags (Optional[int]): Message flags.
             view (Optional[View]): A view to send with the message.
 
@@ -922,6 +924,7 @@ class Client:
             allowed_mentions=allowed_mentions,
             message_reference=message_reference,
             attachments=attachments,
+            files=files,
             flags=flags,
         )
 

--- a/disagreement/components.py
+++ b/disagreement/components.py
@@ -18,7 +18,7 @@ from .models import (
     Thumbnail,
     MediaGallery,
     MediaGalleryItem,
-    File,
+    FileComponent,
     Separator,
     Container,
     UnfurledMediaItem,
@@ -140,7 +140,7 @@ def component_factory(
         )
 
     if ctype == ComponentType.FILE:
-        return File(
+        return FileComponent(
             file=UnfurledMediaItem(**data["file"]),
             spoiler=data.get("spoiler", False),
             id=data.get("id"),

--- a/disagreement/models.py
+++ b/disagreement/models.py
@@ -377,6 +377,14 @@ class Attachment:
         return payload
 
 
+class File:
+    """Represents a file to be uploaded."""
+
+    def __init__(self, filename: str, data: bytes):
+        self.filename = filename
+        self.data = data
+
+
 class AllowedMentions:
     """Represents allowed mentions for a message or interaction response."""
 
@@ -1459,7 +1467,7 @@ class MediaGallery(Component):
         return payload
 
 
-class File(Component):
+class FileComponent(Component):
     """Represents a file component."""
 
     def __init__(

--- a/tests/test_send_files.py
+++ b/tests/test_send_files.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock
 
 from disagreement.client import Client
 from disagreement.http import HTTPClient
-from disagreement.models import Attachment
+from disagreement.models import Attachment, File
 
 
 @pytest.mark.asyncio
@@ -27,6 +27,23 @@ async def test_http_send_message_includes_attachments():
 
 
 @pytest.mark.asyncio
+async def test_http_send_message_with_files_uses_formdata():
+    http = HTTPClient(token="t")
+    http.request = AsyncMock(
+        return_value={
+            "id": "1",
+            "channel_id": "c",
+            "author": {"id": "2", "username": "u", "discriminator": "0001"},
+            "content": "hi",
+            "timestamp": "t",
+        }
+    )
+    await http.send_message("c", "hi", files=[File("f.txt", b"data")])
+    args, kwargs = http.request.call_args
+    assert kwargs["is_json"] is False
+
+
+@pytest.mark.asyncio
 async def test_client_send_message_passes_attachments():
     client = Client(token="t")
     client._http.send_message = AsyncMock(
@@ -44,3 +61,21 @@ async def test_client_send_message_passes_attachments():
     kwargs = client._http.send_message.call_args.kwargs
     assert kwargs["attachments"] == [{"id": "1"}]
     assert isinstance(msg.attachments[0], Attachment)
+
+
+@pytest.mark.asyncio
+async def test_client_send_message_passes_files():
+    client = Client(token="t")
+    client._http.send_message = AsyncMock(
+        return_value={
+            "id": "1",
+            "channel_id": "c",
+            "author": {"id": "2", "username": "u", "discriminator": "0001"},
+            "content": "hi",
+            "timestamp": "t",
+        }
+    )
+    await client.send_message("c", "hi", files=[File("f.txt", b"data")])
+    client._http.send_message.assert_awaited_once()
+    kwargs = client._http.send_message.call_args.kwargs
+    assert kwargs["files"][0].filename == "f.txt"


### PR DESCRIPTION
## Summary
- add `File` helper for uploads
- rename component `File` -> `FileComponent`
- support multipart uploads in `HTTPClient.send_message`
- pass through `files` in `Client.send_message`
- test multipart behaviour

## Testing
- `black . --quiet`
- `pylint --disable=all --enable=E,F disagreement tests | head`
- `pyright > /tmp/pyright.log && tail -n 20 /tmp/pyright.log`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847d66f39248323a238efd536447047