### PR TITLE
Add Webhook.from_url convenience

### DIFF
--- a/disagreement/models.py
+++ b/disagreement/models.py
@@ -5,6 +5,7 @@ Data models for Discord objects.
 """
 
 import json
+import aiohttp  # pylint: disable=import-error
 from typing import Optional, TYPE_CHECKING, List, Dict, Any, Union
 
 from .errors import DisagreementException, HTTPException
@@ -1114,6 +1115,33 @@ class Webhook:
 
     def __repr__(self) -> str:
         return f"<Webhook id='{self.id}' name='{self.name}'>"
+
+    @classmethod
+    def from_url(
+        cls, url: str, session: Optional[aiohttp.ClientSession] = None
+    ) -> "Webhook":
+        """Create a minimal :class:`Webhook` from a webhook URL.
+
+        Parameters
+        ----------
+        url:
+            The full Discord webhook URL.
+        session:
+            Unused for now. Present for API compatibility.
+
+        Returns
+        -------
+        Webhook
+            A webhook instance containing only the ``id``, ``token`` and ``url``.
+        """
+
+        parts = url.rstrip("/").split("/")
+        if len(parts) < 2:
+            raise ValueError("Invalid webhook URL")
+        token = parts[-1]
+        webhook_id = parts[-2]
+
+        return cls({"id": webhook_id, "token": token, "url": url})
 
 
 # --- Message Components ---

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -31,3 +31,14 @@ from disagreement.models import Webhook
 
 print(webhook.id, webhook.name)
 ```
+
+## Create a Webhook from a URL
+
+You can construct a `Webhook` object from an existing webhook URL without any API calls:
+
+```python
+from disagreement.models import Webhook
+
+webhook = Webhook.from_url("https://discord.com/api/webhooks/123/token")
+print(webhook.id, webhook.token)
+```

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -138,3 +138,14 @@ async def test_client_delete_webhook_calls_http():
     await client.delete_webhook("1")
 
     http.delete_webhook.assert_awaited_once_with("1")
+
+
+def test_webhook_from_url_parses_id_and_token():
+    from disagreement.models import Webhook
+
+    url = "https://discord.com/api/webhooks/123/token"
+    webhook = Webhook.from_url(url)
+
+    assert webhook.id == "123"
+    assert webhook.token == "token"
+    assert webhook.url == url


### PR DESCRIPTION
## Summary
- add `Webhook.from_url` helper
- document building a `Webhook` from a URL
- test `Webhook.from_url`

## Testing
- `black disagreement tests`
- `pyright`
- `pylint --disable=all --enable=E,F disagreement tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847d674e2fc8323b8ce8813cb5b9ba0