### PR TITLE
Refactor voice client with switchable audio sources

### DIFF
--- a/disagreement/__init__.py
+++ b/disagreement/__init__.py
@@ -19,6 +19,7 @@ __version__ = "0.0.2"
 from .client import Client
 from .models import Message, User, Reaction
 from .voice_client import VoiceClient
+from .audio import AudioSource, FFmpegAudioSource
 from .typing import Typing
 from .errors import (
     DisagreementException,

--- a/disagreement/audio.py
+++ b/disagreement/audio.py
@@ -1,0 +1,116 @@
+"""Audio source abstractions for the voice client."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import io
+from typing import Optional, Union
+
+
+class AudioSource:
+    """Abstract base class for audio sources."""
+
+    async def read(self) -> bytes:
+        """Read the next chunk of PCM audio.
+
+        Subclasses must implement this and return raw PCM data
+        at 48kHz stereo (3840 byte chunks).
+        """
+
+        raise NotImplementedError
+
+    async def close(self) -> None:
+        """Cleanup the source when playback ends."""
+
+        return None
+
+
+class FFmpegAudioSource(AudioSource):
+    """Decode audio using FFmpeg.
+
+    Parameters
+    ----------
+    source:
+        A filename, URL, or file-like object to read from.
+    """
+
+    def __init__(self, source: Union[str, io.BufferedIOBase]):
+        self.source = source
+        self.process: Optional[asyncio.subprocess.Process] = None
+        self._feeder: Optional[asyncio.Task] = None
+
+    async def _spawn(self) -> None:
+        if isinstance(self.source, str):
+            args = [
+                "ffmpeg",
+                "-i",
+                self.source,
+                "-f",
+                "s16le",
+                "-ar",
+                "48000",
+                "-ac",
+                "2",
+                "pipe:1",
+            ]
+            self.process = await asyncio.create_subprocess_exec(
+                *args,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+        else:
+            args = [
+                "ffmpeg",
+                "-i",
+                "pipe:0",
+                "-f",
+                "s16le",
+                "-ar",
+                "48000",
+                "-ac",
+                "2",
+                "pipe:1",
+            ]
+            self.process = await asyncio.create_subprocess_exec(
+                *args,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            assert self.process.stdin is not None
+            self._feeder = asyncio.create_task(self._feed())
+
+    async def _feed(self) -> None:
+        assert isinstance(self.source, io.BufferedIOBase)
+        assert self.process is not None
+        assert self.process.stdin is not None
+        while True:
+            data = await asyncio.to_thread(self.source.read, 4096)
+            if not data:
+                break
+            self.process.stdin.write(data)
+            await self.process.stdin.drain()
+        self.process.stdin.close()
+
+    async def read(self) -> bytes:
+        if self.process is None:
+            await self._spawn()
+        assert self.process is not None
+        assert self.process.stdout is not None
+        data = await self.process.stdout.read(3840)
+        if not data:
+            await self.close()
+        return data
+
+    async def close(self) -> None:
+        if self._feeder:
+            self._feeder.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._feeder
+        if self.process:
+            await self.process.wait()
+            self.process = None
+        if isinstance(self.source, io.IOBase):
+            with contextlib.suppress(Exception):
+                self.source.close()

--- a/docs/voice_client.md
+++ b/docs/voice_client.md
@@ -26,10 +26,19 @@ After connecting you can send raw Opus frames:
 await vc.send_audio_frame(opus_bytes)
 ```
 
-Or stream a file using FFmpeg:
+Or stream audio using an :class:`AudioSource`:
 
 ```python
-await vc.play_file("welcome.mp3")
+from disagreement import FFmpegAudioSource
+
+source = FFmpegAudioSource("welcome.mp3")
+await vc.play(source)
+```
+
+You can switch sources while connected:
+
+```python
+await vc.play(FFmpegAudioSource("other.mp3"))
 ```
 
 Call `await vc.close()` when finished.

--- a/docs/voice_features.md
+++ b/docs/voice_features.md
@@ -1,10 +1,11 @@
 # Voice Features
 
-Disagreement includes experimental support for connecting to voice channels. You can join a voice channel and play audio using an FFmpeg subprocess.
+Disagreement includes experimental support for connecting to voice channels. You can join a voice channel and play audio using an :class:`AudioSource`.
 
 ```python
 voice = await client.join_voice(guild_id, channel_id)
 await voice.play_file("welcome.mp3")
+await voice.play_file("another.mp3")  # switch sources while connected
 await voice.close()
 ```
 


### PR DESCRIPTION
## Summary
- add `AudioSource` abstraction with `FFmpegAudioSource`
- refactor `VoiceClient` to play and switch `AudioSource`s
- document new voice API
- update voice client tests for new behaviour

## Testing
- `black disagreement tests docs`
- `pylint --disable=all --enable=E,F disagreement tests`
- `pyright`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847d699f3c08323869446b05cf3e1d8