### PR TITLE
Implement Message.delete

### DIFF
--- a/disagreement/http.py
+++ b/disagreement/http.py
@@ -269,6 +269,13 @@ class HTTPClient:
             "GET", f"/channels/{channel_id}/messages/{message_id}"
         )
 
+    async def delete_message(
+        self, channel_id: "Snowflake", message_id: "Snowflake"
+    ) -> None:
+        """Deletes a message in a channel."""
+
+        await self.request("DELETE", f"/channels/{channel_id}/messages/{message_id}")
+
     async def create_reaction(
         self, channel_id: "Snowflake", message_id: "Snowflake", emoji: str
     ) -> None:

--- a/disagreement/models.py
+++ b/disagreement/models.py
@@ -5,6 +5,7 @@ Data models for Discord objects.
 """
 
 import json
+import asyncio
 from typing import Optional, TYPE_CHECKING, List, Dict, Any, Union
 
 from .errors import DisagreementException, HTTPException
@@ -195,6 +196,22 @@ class Message:
             flags=flags,
             view=view,
         )
+
+    async def delete(self, delay: Optional[float] = None) -> None:
+        """|coro|
+
+        Deletes this message.
+
+        Parameters
+        ----------
+        delay:
+            If provided, wait this many seconds before deleting.
+        """
+
+        if delay is not None:
+            await asyncio.sleep(delay)
+
+        await self._client._http.delete_message(self.channel_id, self.id)
 
     def __repr__(self) -> str:
         return f"<Message id='{self.id}' channel_id='{self.channel_id}' author='{self.author!r}'>"


### PR DESCRIPTION
## Summary
- add asyncio import for new sleep usage
- support deleting a message through `Message.delete`
- expose `HTTPClient.delete_message` REST helper

## Testing
- `pyright`
- `pylint --disable=all --enable=E,F $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847d6c2a9788323a99527766f8571b6