### PR TITLE
Add flexible scheduling to tasks

### DIFF
--- a/docs/task_loop.md
+++ b/docs/task_loop.md
@@ -1,11 +1,11 @@
 # Task Loops
 
-The tasks extension allows you to run functions periodically. Decorate an async function with `@tasks.loop(seconds=...)` and start it using `.start()`.
+The tasks extension allows you to run functions periodically. Decorate an async function with `@tasks.loop` and start it using `.start()`.
 
 ```python
 from disagreement.ext import tasks
 
-@tasks.loop(seconds=5.0)
+@tasks.loop(minutes=1.0)
 async def announce():
     print("Hello from a loop")
 
@@ -13,3 +13,36 @@ announce.start()
 ```
 
 Stop the loop with `.stop()` when you no longer need it.
+
+You can provide the interval in seconds, minutes, hours or as a `datetime.timedelta`:
+
+```python
+import datetime
+
+@tasks.loop(delta=datetime.timedelta(seconds=30))
+async def ping():
+    ...
+```
+
+Handle exceptions raised by the looped coroutine using `on_error`:
+
+```python
+async def log_error(exc: Exception) -> None:
+    print("Loop failed:", exc)
+
+@tasks.loop(seconds=5.0, on_error=log_error)
+async def worker():
+    ...
+```
+
+You can also schedule a task at a specific time of day:
+
+```python
+from datetime import datetime, timedelta
+
+time_to_run = (datetime.now() + timedelta(seconds=5)).time()
+
+@tasks.loop(time_of_day=time_to_run)
+async def daily_task():
+    ...
+```


### PR DESCRIPTION
## Summary
- expand looping tasks to support minutes, hours, timedelta and `time_of_day`
- add optional `on_error` callbacks for loops
- document all new options with examples
- test the new behaviour

## Testing
- `black disagreement/ext/tasks.py tests/test_tasks_extension.py`
- `pylint disagreement/ext/tasks.py tests/test_tasks_extension.py --disable=all --enable=E,F`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847d6b56fd083239340eaf45eff20c0