### PR TITLE
Add reconnect backoff options

### DIFF
--- a/disagreement/client.py
+++ b/disagreement/client.py
@@ -84,6 +84,8 @@ class Client:
         verbose: bool = False,
         mention_replies: bool = False,
         shard_count: Optional[int] = None,
+        gateway_max_retries: int = 5,
+        gateway_max_backoff: float = 60.0,
     ):
         if not token:
             raise ValueError("A bot token must be provided.")
@@ -103,6 +105,8 @@ class Client:
             None  # Initialized in run() or connect()
         )
         self.shard_count: Optional[int] = shard_count
+        self.gateway_max_retries: int = gateway_max_retries
+        self.gateway_max_backoff: float = gateway_max_backoff
         self._shard_manager: Optional[ShardManager] = None
 
         # Initialize CommandHandler
@@ -169,6 +173,8 @@ class Client:
                 intents=self.intents,
                 client_instance=self,
                 verbose=self.verbose,
+                max_retries=self.gateway_max_retries,
+                max_backoff=self.gateway_max_backoff,
             )
 
     async def _initialize_shard_manager(self) -> None:

--- a/disagreement/shard_manager.py
+++ b/disagreement/shard_manager.py
@@ -51,6 +51,8 @@ class ShardManager:
                 verbose=self.client.verbose,
                 shard_id=shard_id,
                 shard_count=self.shard_count,
+                max_retries=self.client.gateway_max_retries,
+                max_backoff=self.client.gateway_max_backoff,
             )
             self.shards.append(Shard(shard_id, self.shard_count, gateway))
 

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -4,7 +4,8 @@
 
 The default behaviour tries up to five reconnect attempts, doubling the delay each time up to a configurable maximum. A small random jitter is added to spread out reconnect attempts when multiple clients restart at once.
 
-You can control the maximum number of retries and the backoff cap when constructing `Client`:
+You can control the maximum number of retries and the backoff cap when constructing `Client`.
+These options are forwarded to `GatewayClient` as `max_retries` and `max_backoff`:
 
 ```python
 bot = Client(

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -18,6 +18,8 @@ class DummyClient:
         self.token = "t"
         self.intents = 0
         self.verbose = False
+        self.gateway_max_retries = 5
+        self.gateway_max_backoff = 60.0
 
 
 def test_shard_manager_creates_shards(monkeypatch):


### PR DESCRIPTION
## Summary
- add `max_retries` and `max_backoff` to `GatewayClient` and reconnect with exponential backoff
- expose retry settings on `Client` and shard manager
- document reconnect behaviour and configuration
- test gateway reconnection logic

## Testing
- `pyright`
- `pylint disagreement/gateway.py disagreement/client.py disagreement/shard_manager.py tests/test_gateway_backoff.py tests/test_sharding.py --disable=all --enable=E,F`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847d6cfe9fc8323b00b0de4f1733493