### PR TITLE
Add GatewayIntent.none with docs and tests

### DIFF
--- a/disagreement/enums.py
+++ b/disagreement/enums.py
@@ -50,6 +50,11 @@ class GatewayIntent(IntEnum):
     AUTO_MODERATION_EXECUTION = 1 << 21
 
     @classmethod
+    def none(cls) -> int:
+        """Return a bitmask representing no intents."""
+        return 0
+
+    @classmethod
     def default(cls) -> int:
         """Returns default intents (excluding privileged ones like members, presences, message content)."""
         return (

--- a/docs/gateway.md
+++ b/docs/gateway.md
@@ -16,3 +16,9 @@ bot = Client(
 ```
 
 These values are passed to `GatewayClient` and applied whenever the connection needs to be re-established.
+
+## Gateway Intents
+
+`GatewayIntent` values control which events your bot receives from the Gateway. Use
+`GatewayIntent.none()` to opt out of all events entirely. It returns `0`, which
+represents a bitmask with no intents enabled.

--- a/tests/test_gateway_intent.py
+++ b/tests/test_gateway_intent.py
@@ -1,0 +1,7 @@
+import pytest
+
+from disagreement.enums import GatewayIntent
+
+
+def test_gateway_intent_none_equals_zero():
+    assert GatewayIntent.none() == 0

--- a/tests/test_modals.py
+++ b/tests/test_modals.py
@@ -28,5 +28,6 @@ async def test_respond_modal(dummy_bot, interaction):
     await interaction.respond_modal(modal)
     dummy_bot._http.create_interaction_response.assert_called_once()
     payload = dummy_bot._http.create_interaction_response.call_args.kwargs["payload"]
-    assert payload["type"] == InteractionCallbackType.MODAL.value
-    assert payload["data"]["custom_id"] == "m1"
+    data = payload.to_dict()
+    assert data["type"] == InteractionCallbackType.MODAL.value
+    assert data["data"]["custom_id"] == "m1"


### PR DESCRIPTION
## Summary
- implement `GatewayIntent.none()` returning zero
- document the new method in gateway docs
- test `GatewayIntent.none()` and fix modal test

## Testing
- `pylint disagreement/enums.py tests/test_gateway_intent.py tests/test_modals.py --disable=all --enable=E,F`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848c25616c48323bbb07d22bf6e08e5