### PR TITLE
Implement TextChannel history

### DIFF
--- a/disagreement/__init__.py
+++ b/disagreement/__init__.py
@@ -30,7 +30,7 @@ from .errors import (
     NotFound,
 )
 from .color import Color
-from .utils import utcnow
+from .utils import utcnow, message_pager
 from .enums import GatewayIntent, GatewayOpcode  # Export enums
 from .error_handler import setup_global_error_handler
 from .hybrid_context import HybridContext

--- a/disagreement/models.py
+++ b/disagreement/models.py
@@ -8,7 +8,7 @@ import json
 import asyncio
 import aiohttp  # pylint: disable=import-error
 import asyncio
-from typing import Optional, TYPE_CHECKING, List, Dict, Any, Union
+from typing import Any, AsyncIterator, Dict, List, Optional, TYPE_CHECKING, Union
 
 from .errors import DisagreementException, HTTPException
 from .enums import (  # These enums will need to be defined in disagreement/enums.py
@@ -1064,6 +1064,19 @@ class TextChannel(Channel):
             "default_auto_archive_duration"
         )
         self.last_pin_timestamp: Optional[str] = data.get("last_pin_timestamp")
+
+    def history(
+        self,
+        *,
+        limit: Optional[int] = None,
+        before: Optional[str] = None,
+        after: Optional[str] = None,
+    ) -> AsyncIterator["Message"]:
+        """Return an async iterator over this channel's messages."""
+
+        from .utils import message_pager
+
+        return message_pager(self, limit=limit, before=before, after=after)
 
     async def send(
         self,

--- a/disagreement/utils.py
+++ b/disagreement/utils.py
@@ -3,8 +3,71 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import Any, AsyncIterator, Dict, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for type hinting only
+    from .models import Message, TextChannel
 
 
 def utcnow() -> datetime:
     """Return the current timezone-aware UTC time."""
     return datetime.now(timezone.utc)
+
+
+async def message_pager(
+    channel: "TextChannel",
+    *,
+    limit: Optional[int] = None,
+    before: Optional[str] = None,
+    after: Optional[str] = None,
+) -> AsyncIterator["Message"]:
+    """Asynchronously paginate a channel's messages.
+
+    Parameters
+    ----------
+    channel:
+        The :class:`TextChannel` to fetch messages from.
+    limit:
+        The maximum number of messages to yield. ``None`` fetches until no
+        more messages are returned.
+    before:
+        Fetch messages with IDs less than this snowflake.
+    after:
+        Fetch messages with IDs greater than this snowflake.
+
+    Yields
+    ------
+    Message
+        Messages in the channel, oldest first.
+    """
+
+    remaining = limit
+    last_id = before
+    while remaining is None or remaining > 0:
+        fetch_limit = 100
+        if remaining is not None:
+            fetch_limit = min(fetch_limit, remaining)
+
+        params: Dict[str, Any] = {"limit": fetch_limit}
+        if last_id is not None:
+            params["before"] = last_id
+        if after is not None:
+            params["after"] = after
+
+        data = await channel._client._http.request(  # type: ignore[attr-defined]
+            "GET",
+            f"/channels/{channel.id}/messages",
+            params=params,
+        )
+
+        if not data:
+            break
+
+        for raw in data:
+            msg = channel._client.parse_message(raw)  # type: ignore[attr-defined]
+            yield msg
+            last_id = msg.id
+            if remaining is not None:
+                remaining -= 1
+                if remaining == 0:
+                    return

--- a/docs/message_history.md
+++ b/docs/message_history.md
@@ -1,0 +1,16 @@
+# Message History
+
+`TextChannel.history` provides an async iterator over a channel's past messages. The iterator is powered by `utils.message_pager` which handles pagination for you.
+
+```python
+channel = await client.fetch_channel(123456789012345678)
+async for message in channel.history(limit=200):
+    print(message.content)
+```
+
+Pass `before` or `after` to control the range of messages returned. The paginator fetches messages in batches of up to 100 until the limit is reached or Discord returns no more messages.
+
+## Next Steps
+
+- [Caching](caching.md)
+- [Typing Indicator](typing_indicator.md)

--- a/examples/message_history.py
+++ b/examples/message_history.py
@@ -1,0 +1,31 @@
+"""Example showing how to read a channel's message history."""
+
+import asyncio
+import os
+import sys
+
+# Allow running example from repository root
+if os.path.join(os.getcwd(), "examples") == os.path.dirname(os.path.abspath(__file__)):
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from disagreement.client import Client
+from disagreement.models import TextChannel
+from dotenv import load_dotenv
+
+load_dotenv()
+
+BOT_TOKEN = os.environ.get("DISCORD_BOT_TOKEN", "")
+CHANNEL_ID = os.environ.get("DISCORD_CHANNEL_ID", "")
+
+client = Client(token=BOT_TOKEN)
+
+
+async def main() -> None:
+    channel = await client.fetch_channel(CHANNEL_ID)
+    if isinstance(channel, TextChannel):
+        async for message in channel.history(limit=10):
+            print(message.content)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_message_pager.py
+++ b/tests/test_message_pager.py
@@ -1,0 +1,37 @@
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from disagreement.client import Client
+from disagreement.models import TextChannel
+from disagreement.utils import message_pager
+
+
+@pytest.mark.asyncio
+async def test_message_pager_fetches_until_empty():
+    calls = [
+        [
+            {
+                "id": "1",
+                "channel_id": "c",
+                "author": {"id": "2", "username": "u", "discriminator": "0001"},
+                "content": "hi",
+                "timestamp": "t",
+            }
+        ],
+        [],
+    ]
+    http = SimpleNamespace(request=AsyncMock(side_effect=calls))
+    client = Client.__new__(Client)
+    client._http = http
+    from disagreement.models import Message
+
+    client.parse_message = lambda d: Message(d, client_instance=client)
+    channel = TextChannel({"id": "c", "type": 0}, client)
+
+    messages = []
+    async for m in message_pager(channel):
+        messages.append(m)
+
+    assert len(messages) == 1
+    http.request.assert_awaited()

--- a/tests/test_textchannel_history.py
+++ b/tests/test_textchannel_history.py
@@ -1,0 +1,24 @@
+import pytest
+
+from disagreement.client import Client
+from disagreement.models import TextChannel
+
+
+@pytest.mark.asyncio
+async def test_textchannel_history_delegates(monkeypatch):
+    called = {}
+
+    async def fake_pager(channel, *, limit=None, before=None, after=None):
+        called["args"] = (channel, limit, before, after)
+        if False:
+            yield None
+
+    monkeypatch.setattr("disagreement.utils.message_pager", fake_pager)
+    client = Client.__new__(Client)
+    channel = TextChannel({"id": "c", "type": 0}, client)
+
+    hist = channel.history(limit=2, before="b")
+    with pytest.raises(StopAsyncIteration):
+        await hist.__anext__()
+
+    assert called["args"] == (channel, 2, "b", None)


### PR DESCRIPTION
## Summary
- add `message_pager` async iterator utility
- expose `message_pager` at the package level
- integrate `TextChannel.history` with the new paginator
- document history usage
- provide example script
- test the paginator and new channel method

## Testing
- `pylint --disable=all --enable=E,F disagreement`
- `pyright`
- `pytest -q` *(fails: tests/test_modals.py::test_respond_modal)*

------
https://chatgpt.com/codex/tasks/task_e_6848c280a63c8323984422d18b26a7ae