### PR TITLE
Implement webhook send

### DIFF
--- a/disagreement/interactions.py
+++ b/disagreement/interactions.py
@@ -503,9 +503,7 @@ class InteractionCallbackData:
         self.tts: Optional[bool] = data.get("tts")
         self.content: Optional[str] = data.get("content")
         self.embeds: Optional[List[Embed]] = (
-            [Embed(e) for e in data.get("embeds", [])]
-            if data.get("embeds")
-            else None
+            [Embed(e) for e in data.get("embeds", [])] if data.get("embeds") else None
         )
         self.allowed_mentions: Optional[AllowedMentions] = (
             AllowedMentions(data["allowed_mentions"])
@@ -572,3 +570,6 @@ class InteractionResponsePayload:
 
     def __repr__(self) -> str:
         return f"<InteractionResponsePayload type={self.type!r}>"
+
+    def __getitem__(self, key: str) -> Any:
+        return self.to_dict()[key]

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -42,3 +42,12 @@ from disagreement.models import Webhook
 webhook = Webhook.from_url("https://discord.com/api/webhooks/123/token")
 print(webhook.id, webhook.token)
 ```
+
+## Send a message through a Webhook
+
+Once you have a `Webhook` instance bound to a :class:`Client`, you can send messages using it:
+
+```python
+webhook = await client.create_webhook("123", {"name": "Bot Webhook"})
+await webhook.send(content="Hello from my webhook!", username="Bot")
+```


### PR DESCRIPTION
## Summary
- add `HTTPClient.execute_webhook`
- support sending messages via `Webhook.send`
- document sending through a webhook
- test webhook execution helpers
- allow `InteractionResponsePayload` to act like a mapping

## Testing
- `pylint --disable=all --enable=E,F disagreement/http.py disagreement/models.py disagreement/interactions.py tests/test_webhooks.py`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848c273f36483239f365145b5510a1d