### PR TITLE
Fix application_id reuse and handler instantiation

### DIFF
--- a/disagreement/client.py
+++ b/disagreement/client.py
@@ -123,13 +123,9 @@ class Client:
 
         self._closed: bool = False
         self._ready_event: asyncio.Event = asyncio.Event()
-        self.application_id: Optional[Snowflake] = None  # For Application Commands
         self.user: Optional["User"] = (
             None  # The bot's own user object, populated on READY
         )
-
-        # Initialize AppCommandHandler
-        self.app_command_handler: AppCommandHandler = AppCommandHandler(client=self)
 
         # Internal Caches
         self._guilds: Dict[Snowflake, "Guild"] = {}


### PR DESCRIPTION
## Summary
- don't overwrite `application_id` after construction
- only create `AppCommandHandler` once

## Testing
- `black disagreement/client.py`
- `pylint disagreement/client.py --disable=all --enable=E,F`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848cad96df48323bd00933e5fc811b7