### PR TITLE
Improve logging

### DIFF
--- a/disagreement/__init__.py
+++ b/disagreement/__init__.py
@@ -35,7 +35,11 @@ from .enums import GatewayIntent, GatewayOpcode  # Export enums
 from .error_handler import setup_global_error_handler
 from .hybrid_context import HybridContext
 from .ext import tasks
+from .logging_config import setup_logging
 
-# Set up logging if desired
-# import logging
-# logging.getLogger(__name__).addHandler(logging.NullHandler())
+import logging
+
+
+# Configure a default logger if none has been configured yet
+if not logging.getLogger().hasHandlers():
+    setup_logging(logging.INFO)

--- a/disagreement/ext/commands/cog.py
+++ b/disagreement/ext/commands/cog.py
@@ -1,6 +1,7 @@
 # disagreement/ext/commands/cog.py
 
 import inspect
+import logging
 from typing import TYPE_CHECKING, List, Tuple, Callable, Awaitable, Any, Dict, Union
 
 if TYPE_CHECKING:
@@ -15,6 +16,8 @@ else:  # pragma: no cover - runtime imports for isinstance checks
 
     # EventDispatcher might be needed if cogs register listeners directly
     # from disagreement.event_dispatcher import EventDispatcher
+
+logger = logging.getLogger(__name__)
 
 
 class Cog:
@@ -59,8 +62,10 @@ class Cog:
                 cmd.cog = self  # Assign the cog instance to the command
                 if cmd.name in self._commands:
                     # This should ideally be caught earlier or handled by CommandHandler
-                    print(
-                        f"Warning: Duplicate command name '{cmd.name}' in cog '{self.cog_name}'. Overwriting."
+                    logger.warning(
+                        "Duplicate command name '%s' in cog '%s'. Overwriting.",
+                        cmd.name,
+                        self.cog_name,
                     )
                 self._commands[cmd.name.lower()] = cmd
                 # Also register aliases
@@ -79,8 +84,10 @@ class Cog:
                     # For AppCommandGroup, its commands will have cog set individually if they are AppCommands
                     self._app_commands_and_groups.append(app_cmd_obj)
                 else:
-                    print(
-                        f"Warning: Member '{member_name}' in cog '{self.cog_name}' has '__app_command_object__' but it's not an AppCommand or AppCommandGroup."
+                    logger.warning(
+                        "Member '%s' in cog '%s' has '__app_command_object__' but it's not an AppCommand or AppCommandGroup.",
+                        member_name,
+                        self.cog_name,
                     )
 
             elif isinstance(member, (AppCommand, AppCommandGroup)):
@@ -92,8 +99,10 @@ class Cog:
                 # This is a method decorated with @commands.Cog.listener or @commands.listener
                 if not inspect.iscoroutinefunction(member):
                     # Decorator should have caught this, but double check
-                    print(
-                        f"Warning: Listener '{member_name}' in cog '{self.cog_name}' is not a coroutine. Skipping."
+                    logger.warning(
+                        "Listener '%s' in cog '%s' is not a coroutine. Skipping.",
+                        member_name,
+                        self.cog_name,
                     )
                     continue
 

--- a/disagreement/http.py
+++ b/disagreement/http.py
@@ -5,6 +5,7 @@ HTTP client for interacting with the Discord REST API.
 """
 
 import asyncio
+import logging
 import aiohttp  # pylint: disable=import-error
 import json
 from urllib.parse import quote
@@ -27,6 +28,8 @@ if TYPE_CHECKING:
 
 # Discord API constants
 API_BASE_URL = "https://discord.com/api/v10"  # Using API v10
+
+logger = logging.getLogger(__name__)
 
 
 class HTTPClient:
@@ -86,7 +89,13 @@ class HTTPClient:
             final_headers.update(custom_headers)
 
         if self.verbose:
-            print(f"HTTP REQUEST: {method} {url} | payload={payload} params={params}")
+            logger.debug(
+                "HTTP REQUEST: %s %s | payload=%s params=%s",
+                method,
+                url,
+                payload,
+                params,
+            )
 
         route = f"{method.upper()}:{endpoint}"
 
@@ -119,7 +128,9 @@ class HTTPClient:
                     )  # Fallback to text if JSON parsing fails
 
                 if self.verbose:
-                    print(f"HTTP RESPONSE: {response.status} {url} | {data}")
+                    logger.debug(
+                        "HTTP RESPONSE: %s %s | %s", response.status, url, data
+                    )
 
                 self._rate_limiter.release(route, response.headers)
 
@@ -150,8 +161,12 @@ class HTTPClient:
                     )
 
                     if attempt < 4:  # Don't log on the last attempt before raising
-                        print(
-                            f"{error_message} Retrying after {retry_after}s (Attempt {attempt + 1}/5). Global: {is_global}"
+                        logger.warning(
+                            "%s Retrying after %ss (Attempt %s/5). Global: %s",
+                            error_message,
+                            retry_after,
+                            attempt + 1,
+                            is_global,
                         )
                         continue  # Retry the request
                     else:  # Last attempt failed


### PR DESCRIPTION
## Summary
- configure default logging on import
- log debug messages in the gateway and HTTP modules
- log warnings and errors in command handlers instead of printing

## Testing
- `black disagreement/__init__.py disagreement/gateway.py disagreement/http.py disagreement/ext/commands/core.py disagreement/ext/commands/cog.py disagreement/ext/app_commands/handler.py`
- `pylint disagreement/__init__.py disagreement/gateway.py disagreement/http.py disagreement/ext/commands/core.py disagreement/ext/commands/cog.py disagreement/ext/app_commands/handler.py --disable=all --enable=E,F`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848cadbafbc832383709f176c505376