### PR TITLE
Add py.typed indicator

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 graft docs
 graft examples
 include LICENSE
+include disagreement/py.typed


### PR DESCRIPTION
## Summary
- mark package as typed by adding `py.typed`
- ship the marker in builds via `MANIFEST.in`

## Testing
- `pylint disagreement --disable=all --enable=E,F`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848cadd93b8832391c59d90790aef0e