### PR TITLE
Add more Color helpers

### DIFF
--- a/disagreement/color.py
+++ b/disagreement/color.py
@@ -46,6 +46,103 @@ class Color:
     def blue(cls) -> "Color":
         return cls(0x0000FF)
 
+    # Discord brand colors
+    @classmethod
+    def blurple(cls) -> "Color":
+        """Discord brand blurple (#5865F2)."""
+        return cls(0x5865F2)
+
+    @classmethod
+    def light_blurple(cls) -> "Color":
+        """Light blurple used by Discord (#E0E3FF)."""
+        return cls(0xE0E3FF)
+
+    @classmethod
+    def legacy_blurple(cls) -> "Color":
+        """Legacy Discord blurple (#7289DA)."""
+        return cls(0x7289DA)
+
+    # Additional assorted colors
+    @classmethod
+    def teal(cls) -> "Color":
+        return cls(0x1ABC9C)
+
+    @classmethod
+    def dark_teal(cls) -> "Color":
+        return cls(0x11806A)
+
+    @classmethod
+    def brand_green(cls) -> "Color":
+        return cls(0x57F287)
+
+    @classmethod
+    def dark_green(cls) -> "Color":
+        return cls(0x206694)
+
+    @classmethod
+    def orange(cls) -> "Color":
+        return cls(0xE67E22)
+
+    @classmethod
+    def dark_orange(cls) -> "Color":
+        return cls(0xA84300)
+
+    @classmethod
+    def brand_red(cls) -> "Color":
+        return cls(0xED4245)
+
+    @classmethod
+    def dark_red(cls) -> "Color":
+        return cls(0x992D22)
+
+    @classmethod
+    def magenta(cls) -> "Color":
+        return cls(0xE91E63)
+
+    @classmethod
+    def dark_magenta(cls) -> "Color":
+        return cls(0xAD1457)
+
+    @classmethod
+    def purple(cls) -> "Color":
+        return cls(0x9B59B6)
+
+    @classmethod
+    def dark_purple(cls) -> "Color":
+        return cls(0x71368A)
+
+    @classmethod
+    def yellow(cls) -> "Color":
+        return cls(0xF1C40F)
+
+    @classmethod
+    def dark_gold(cls) -> "Color":
+        return cls(0xC27C0E)
+
+    @classmethod
+    def light_gray(cls) -> "Color":
+        return cls(0x99AAB5)
+
+    @classmethod
+    def dark_gray(cls) -> "Color":
+        return cls(0x2C2F33)
+
+    @classmethod
+    def lighter_gray(cls) -> "Color":
+        return cls(0xBFBFBF)
+
+    @classmethod
+    def darker_gray(cls) -> "Color":
+        return cls(0x23272A)
+
+    @classmethod
+    def black(cls) -> "Color":
+        return cls(0x000000)
+
+    @classmethod
+    def white(cls) -> "Color":
+        return cls(0xFFFFFF)
+
     def to_rgb(self) -> tuple[int, int, int]:
         return ((self.value >> 16) & 0xFF, (self.value >> 8) & 0xFF, self.value & 0xFF)
 

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -11,3 +11,6 @@ def test_static_colors():
     assert Color.red().value == 0xFF0000
     assert Color.green().value == 0x00FF00
     assert Color.blue().value == 0x0000FF
+    assert Color.blurple().value == 0x5865F2
+    assert Color.light_blurple().value == 0xE0E3FF
+    assert Color.legacy_blurple().value == 0x7289DA


### PR DESCRIPTION
## Summary
- expand color helper class with many common brand colors
- add tests for new blurple shades

## Testing
- `pyright`
- `pylint --disable=all --enable=E,F disagreement`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848cff84fe88323a0ba3482199163f0