### PR TITLE
Add guild template support

### DIFF
--- a/disagreement/http.py
+++ b/disagreement/http.py
@@ -589,6 +589,33 @@ class HTTPClient:
         """Fetches a guild object for a given guild ID."""
         return await self.request("GET", f"/guilds/{guild_id}")
 
+    async def get_guild_templates(self, guild_id: "Snowflake") -> List[Dict[str, Any]]:
+        """Fetches all templates for the given guild."""
+        return await self.request("GET", f"/guilds/{guild_id}/templates")
+
+    async def create_guild_template(
+        self, guild_id: "Snowflake", payload: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Creates a guild template."""
+        return await self.request(
+            "POST", f"/guilds/{guild_id}/templates", payload=payload
+        )
+
+    async def sync_guild_template(
+        self, guild_id: "Snowflake", template_code: str
+    ) -> Dict[str, Any]:
+        """Syncs a guild template to the guild's current state."""
+        return await self.request(
+            "PUT",
+            f"/guilds/{guild_id}/templates/{template_code}",
+        )
+
+    async def delete_guild_template(
+        self, guild_id: "Snowflake", template_code: str
+    ) -> None:
+        """Deletes a guild template."""
+        await self.request("DELETE", f"/guilds/{guild_id}/templates/{template_code}")
+
     # Add other methods like:
     # async def get_guild(self, guild_id: str) -> Dict[str, Any]: ...
     # async def create_reaction(self, channel_id: str, message_id: str, emoji: str) -> None: ...

--- a/disagreement/models.py
+++ b/disagreement/models.py
@@ -1433,6 +1433,33 @@ class Webhook:
         return self._client.parse_message(message_data)
 
 
+class GuildTemplate:
+    """Represents a guild template."""
+
+    def __init__(
+        self, data: Dict[str, Any], client_instance: Optional["Client"] = None
+    ):
+        self._client = client_instance
+        self.code: str = data["code"]
+        self.name: str = data["name"]
+        self.description: Optional[str] = data.get("description")
+        self.usage_count: int = data.get("usage_count", 0)
+        self.creator_id: str = data.get("creator_id", "")
+        self.creator: Optional[User] = (
+            User(data["creator"]) if data.get("creator") else None
+        )
+        self.created_at: Optional[str] = data.get("created_at")
+        self.updated_at: Optional[str] = data.get("updated_at")
+        self.source_guild_id: Optional[str] = data.get("source_guild_id")
+        self.serialized_source_guild: Dict[str, Any] = data.get(
+            "serialized_source_guild", {}
+        )
+        self.is_dirty: Optional[bool] = data.get("is_dirty")
+
+    def __repr__(self) -> str:
+        return f"<GuildTemplate code='{self.code}' name='{self.name}'>"
+
+
 # --- Message Components ---
 
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,42 @@
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from disagreement.http import HTTPClient
+from disagreement.client import Client
+from disagreement.models import GuildTemplate
+
+
+@pytest.mark.asyncio
+async def test_get_guild_templates_calls_request():
+    http = HTTPClient(token="t")
+    http.request = AsyncMock(return_value=[])
+    await http.get_guild_templates("1")
+    http.request.assert_called_once_with("GET", "/guilds/1/templates")
+
+
+@pytest.mark.asyncio
+async def test_client_fetch_templates_returns_models():
+    http = SimpleNamespace(
+        get_guild_templates=AsyncMock(
+            return_value=[
+                {
+                    "code": "c",
+                    "name": "n",
+                    "usage_count": 0,
+                    "creator_id": "u",
+                    "created_at": "t",
+                    "updated_at": "t",
+                    "source_guild_id": "g",
+                }
+            ]
+        )
+    )
+    client = Client.__new__(Client)
+    client._http = http
+    client._closed = False
+
+    templates = await client.fetch_templates("g")
+
+    http.get_guild_templates.assert_awaited_once_with("g")
+    assert isinstance(templates[0], GuildTemplate)


### PR DESCRIPTION
## Summary
- add `GuildTemplate` model
- add HTTP endpoints for guild templates
- add `Client` methods for template management
- test template fetch behavior

## Testing
- `black disagreement tests/test_templates.py`
- `pylint disagreement tests/test_templates.py --disable=all --enable=E,F`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848d156dc18832394d2e85ca12c50da