### PR TITLE
Add voice region helpers

### DIFF
--- a/disagreement/client.py
+++ b/disagreement/client.py
@@ -22,7 +22,7 @@ from .http import HTTPClient
 from .gateway import GatewayClient
 from .shard_manager import ShardManager
 from .event_dispatcher import EventDispatcher
-from .enums import GatewayIntent, InteractionType, GatewayOpcode
+from .enums import GatewayIntent, InteractionType, GatewayOpcode, VoiceRegion
 from .errors import DisagreementException, AuthenticationError
 from .typing import Typing
 from .ext.commands.core import CommandHandler
@@ -1218,6 +1218,20 @@ class Client:
         except DisagreementException as e:  # Includes HTTPException
             print(f"Failed to fetch channel {channel_id}: {e}")
             return None
+
+    async def fetch_voice_regions(self) -> List[VoiceRegion]:
+        """Fetches available voice regions."""
+
+        if self._closed:
+            raise DisagreementException("Client is closed.")
+
+        data = await self._http.get_voice_regions()
+        regions = []
+        for region in data:
+            region_id = region.get("id")
+            if region_id:
+                regions.append(VoiceRegion(region_id))
+        return regions
 
     async def create_webhook(
         self, channel_id: Snowflake, payload: Dict[str, Any]

--- a/disagreement/enums.py
+++ b/disagreement/enums.py
@@ -278,6 +278,36 @@ class GuildFeature(str, Enum):  # Changed from IntEnum to Enum
         return str(value)
 
 
+class VoiceRegion(str, Enum):
+    """Voice region identifier."""
+
+    AMSTERDAM = "amsterdam"
+    BRAZIL = "brazil"
+    DUBAI = "dubai"
+    EU_CENTRAL = "eu-central"
+    EU_WEST = "eu-west"
+    EUROPE = "europe"
+    FRANKFURT = "frankfurt"
+    HONGKONG = "hongkong"
+    INDIA = "india"
+    JAPAN = "japan"
+    RUSSIA = "russia"
+    SINGAPORE = "singapore"
+    SOUTHAFRICA = "southafrica"
+    SOUTH_KOREA = "south-korea"
+    SYDNEY = "sydney"
+    US_CENTRAL = "us-central"
+    US_EAST = "us-east"
+    US_SOUTH = "us-south"
+    US_WEST = "us-west"
+    VIP_US_EAST = "vip-us-east"
+    VIP_US_WEST = "vip-us-west"
+
+    @classmethod
+    def _missing_(cls, value):  # type: ignore
+        return str(value)
+
+
 # --- Channel Enums ---
 
 

--- a/disagreement/http.py
+++ b/disagreement/http.py
@@ -873,3 +873,7 @@ class HTTPClient:
     async def trigger_typing(self, channel_id: str) -> None:
         """Sends a typing indicator to the specified channel."""
         await self.request("POST", f"/channels/{channel_id}/typing")
+
+    async def get_voice_regions(self) -> List[Dict[str, Any]]:
+        """Returns available voice regions."""
+        return await self.request("GET", "/voice/regions")

--- a/docs/voice_client.md
+++ b/docs/voice_client.md
@@ -42,3 +42,14 @@ await vc.play(FFmpegAudioSource("other.mp3"))
 ```
 
 Call `await vc.close()` when finished.
+
+## Fetching Available Voice Regions
+
+Use :meth:`Client.fetch_voice_regions` to list the voice regions that Discord
+currently offers. The method returns a list of :class:`VoiceRegion` values.
+
+```python
+regions = await client.fetch_voice_regions()
+for region in regions:
+    print(region.value)
+```


### PR DESCRIPTION
## Summary
- add `VoiceRegion` enum to describe available voice regions
- add HTTP client helper to fetch `/voice/regions`
- expose `Client.fetch_voice_regions`
- document new method in voice client docs

## Testing
- `black disagreement/enums.py disagreement/http.py disagreement/client.py`
- `pylint disagreement/enums.py disagreement/http.py disagreement/client.py --disable=all --enable=E,F`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848d15cb708832397d0ae2d230fd3af