### PR TITLE
Add shard lifecycle events

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -98,3 +98,36 @@ Emitted when a guild role is updated. The callback receives a
 async def on_guild_role_update(event: disagreement.GuildRoleUpdate):
     ...
 ```
+
+## SHARD_CONNECT
+
+Fired when a shard establishes its gateway connection. The callback receives a
+dictionary with the shard ID.
+
+```python
+@client.event
+async def on_shard_connect(info: dict):
+    print("shard connected", info["shard_id"])
+```
+
+## SHARD_DISCONNECT
+
+Emitted when a shard's gateway connection is closed. The callback receives a
+dictionary with the shard ID.
+
+```python
+@client.event
+async def on_shard_disconnect(info: dict):
+    ...
+```
+
+## SHARD_RESUME
+
+Sent when a shard successfully resumes after a reconnect. The callback receives
+a dictionary with the shard ID.
+
+```python
+@client.event
+async def on_shard_resume(info: dict):
+    ...
+```


### PR DESCRIPTION
## Summary
- emit shard lifecycle events from the gateway
- document new shard events
- test event callbacks when shards connect, disconnect, and resume

## Testing
- `pylint disagreement/gateway.py tests/test_sharding.py --disable=all --enable=E,F`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848d16398f48323bda45357a201e7ee