### PR TITLE
Add optional HTTP session settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,22 @@ setup_logging(logging.INFO)
 setup_logging(logging.DEBUG, file="bot.log")
 ```
 
+### HTTP Session Options
+
+Pass additional keyword arguments to ``aiohttp.ClientSession`` using the
+``http_options`` parameter when constructing :class:`disagreement.Client`:
+
+```python
+client = disagreement.Client(
+    token=token,
+    http_options={"proxy": "http://localhost:8080"},
+)
+```
+
+These options are forwarded to ``HTTPClient`` when it creates the underlying
+``aiohttp.ClientSession``. You can specify a custom ``connector`` or any other
+session parameter supported by ``aiohttp``.
+
 ### Defining Subcommands with `AppCommandGroup`
 
 ```python

--- a/disagreement/client.py
+++ b/disagreement/client.py
@@ -72,6 +72,9 @@ class Client:
         command_prefix (Union[str, List[str], Callable[['Client', Message], Union[str, List[str]]]]):
             The prefix(es) for commands. Defaults to '!'.
         verbose (bool): If True, print raw HTTP and Gateway traffic for debugging.
+        http_options (Optional[Dict[str, Any]]): Extra options passed to
+            :class:`HTTPClient` for creating the internal
+            :class:`aiohttp.ClientSession`.
     """
 
     def __init__(
@@ -88,6 +91,7 @@ class Client:
         shard_count: Optional[int] = None,
         gateway_max_retries: int = 5,
         gateway_max_backoff: float = 60.0,
+        http_options: Optional[Dict[str, Any]] = None,
     ):
         if not token:
             raise ValueError("A bot token must be provided.")
@@ -101,7 +105,11 @@ class Client:
         setup_global_error_handler(self.loop)
 
         self.verbose: bool = verbose
-        self._http: HTTPClient = HTTPClient(token=self.token, verbose=verbose)
+        self._http: HTTPClient = HTTPClient(
+            token=self.token,
+            verbose=verbose,
+            **(http_options or {}),
+        )
         self._event_dispatcher: EventDispatcher = EventDispatcher(client_instance=self)
         self._gateway: Optional[GatewayClient] = (
             None  # Initialized in run() or connect()

--- a/disagreement/http.py
+++ b/disagreement/http.py
@@ -40,11 +40,26 @@ class HTTPClient:
         token: str,
         client_session: Optional[aiohttp.ClientSession] = None,
         verbose: bool = False,
+        **session_kwargs: Any,
     ):
+        """Create a new HTTP client.
+
+        Parameters
+        ----------
+        token:
+            Bot token for authentication.
+        client_session:
+            Optional existing :class:`aiohttp.ClientSession`.
+        verbose:
+            If ``True``, log HTTP requests and responses.
+        **session_kwargs:
+            Additional options forwarded to :class:`aiohttp.ClientSession`, such
+            as ``proxy`` or ``connector``.
+        """
+
         self.token = token
-        self._session: Optional[aiohttp.ClientSession] = (
-            client_session  # Can be externally managed
-        )
+        self._session: Optional[aiohttp.ClientSession] = client_session
+        self._session_kwargs: Dict[str, Any] = session_kwargs
         self.user_agent = f"DiscordBot (https://github.com/Slipstreamm/disagreement, {__version__})"  # Customize URL
 
         self.verbose = verbose
@@ -53,7 +68,7 @@ class HTTPClient:
 
     async def _ensure_session(self):
         if self._session is None or self._session.closed:
-            self._session = aiohttp.ClientSession()
+            self._session = aiohttp.ClientSession(**self._session_kwargs)
 
     async def close(self):
         """Closes the underlying aiohttp.ClientSession."""

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -24,4 +24,5 @@ client.cache.clear()
 - [Components](using_components.md)
 - [Slash Commands](slash_commands.md)
 - [Voice Features](voice_features.md)
+- [HTTP Client Options](http_client.md)
 

--- a/docs/http_client.md
+++ b/docs/http_client.md
@@ -1,0 +1,20 @@
+# HTTP Client Options
+
+Disagreement uses `aiohttp` for all HTTP requests. Additional options for the
+underlying `aiohttp.ClientSession` can be provided when constructing a
+`Client` or an `HTTPClient` directly.
+
+```python
+import aiohttp
+from disagreement import Client
+
+connector = aiohttp.TCPConnector(limit=50)
+client = Client(
+    token="YOUR_TOKEN",
+    http_options={"proxy": "http://localhost:8080", "connector": connector},
+)
+```
+
+These options are passed through to `aiohttp.ClientSession` when the session is
+created. You can set a proxy URL, provide a custom connector, or supply any
+other supported session argument.

--- a/docs/message_history.md
+++ b/docs/message_history.md
@@ -14,3 +14,4 @@ Pass `before` or `after` to control the range of messages returned. The paginato
 
 - [Caching](caching.md)
 - [Typing Indicator](typing_indicator.md)
+- [HTTP Client Options](http_client.md)

--- a/docs/slash_commands.md
+++ b/docs/slash_commands.md
@@ -19,4 +19,5 @@ Use `AppCommandGroup` to group related commands. See the [components guide](usin
 - [Components](using_components.md)
 - [Caching](caching.md)
 - [Voice Features](voice_features.md)
+- [HTTP Client Options](http_client.md)
 

--- a/docs/using_components.md
+++ b/docs/using_components.md
@@ -165,4 +165,5 @@ A container can itself contain layout and content components, letting you build 
 - [Slash Commands](slash_commands.md)
 - [Caching](caching.md)
 - [Voice Features](voice_features.md)
+- [HTTP Client Options](http_client.md)
 

--- a/docs/voice_features.md
+++ b/docs/voice_features.md
@@ -16,4 +16,5 @@ Voice support is optional and may require additional system dependencies such as
 - [Components](using_components.md)
 - [Slash Commands](slash_commands.md)
 - [Caching](caching.md)
+- [HTTP Client Options](http_client.md)
 


### PR DESCRIPTION
## Summary
- pass aiohttp.ClientSession kwargs through HTTPClient
- allow Client to forward HTTP options
- document the new options in README
- add an HTTP client docs page and cross-links

## Testing
- `pyright`
- `pylint --disable=all --enable=E,F disagreement`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848d15f4fd08323a7877828c2a51d2f