### PR TITLE
Implement command ID persistence

### DIFF
--- a/docs/slash_commands.md
+++ b/docs/slash_commands.md
@@ -20,3 +20,14 @@ Use `AppCommandGroup` to group related commands. See the [components guide](usin
 - [Caching](caching.md)
 - [Voice Features](voice_features.md)
 
+## Command Persistence
+
+`AppCommandHandler.sync_commands` can persist registered command IDs in
+`.disagreement_commands.json`. When enabled, subsequent syncs compare the
+stored IDs to the commands defined in code and only create, edit or delete
+commands when changes are detected.
+
+Call `AppCommandHandler.clear_stored_registrations()` if you need to wipe the
+stored IDs or migrate them elsewhere with
+`AppCommandHandler.migrate_stored_registrations()`.
+


### PR DESCRIPTION
## Summary
- persist application command IDs in `.disagreement_commands.json`
- skip syncing when commands haven't changed
- expose helpers to clear or migrate stored registrations
- document command persistence workflow

## Testing
- `black disagreement/ext/app_commands/handler.py`
- `pyright`
- `pylint disagreement/ext/app_commands/handler.py --disable=all --enable=E,F`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848d189da0c8323a69bcbfb49ec9c75