### PR TITLE
Fix deprecated asyncio loop usage

### DIFF
--- a/disagreement/client.py
+++ b/disagreement/client.py
@@ -75,7 +75,11 @@ class Client:
         intents (Optional[int]): The Gateway Intents to use. Defaults to `GatewayIntent.default()`.
                                  You might need to enable privileged intents in your bot's application page.
         loop (Optional[asyncio.AbstractEventLoop]): The event loop to use for asynchronous operations.
-                                                    Defaults to `asyncio.get_event_loop()`.
+                                                    Defaults to the running loop
+                                                    via `asyncio.get_running_loop()`,
+                                                    or a new loop from
+                                                    `asyncio.new_event_loop()` if
+                                                    none is running.
         command_prefix (Union[str, List[str], Callable[['Client', Message], Union[str, List[str]]]]):
             The prefix(es) for commands. Defaults to '!'.
         verbose (bool): If True, print raw HTTP and Gateway traffic for debugging.
@@ -693,7 +697,7 @@ class Client:
             )
             # import traceback
             # traceback.print_exception(type(error.original), error.original, error.original.__traceback__)
- 
+
     async def on_command_completion(self, ctx: "CommandContext") -> None:
         """
         Default command completion handler. Called when a command has successfully completed.
@@ -1514,35 +1518,35 @@ class Client:
         return [self.parse_invite(inv) for inv in data]
 
     def add_persistent_view(self, view: "View") -> None:
-       """
-       Registers a persistent view with the client.
+        """
+        Registers a persistent view with the client.
 
-       Persistent views have a timeout of `None` and their components must have a `custom_id`.
-       This allows the view to be re-instantiated across bot restarts.
+        Persistent views have a timeout of `None` and their components must have a `custom_id`.
+        This allows the view to be re-instantiated across bot restarts.
 
-       Args:
-           view (View): The view instance to register.
+        Args:
+            view (View): The view instance to register.
 
-       Raises:
-           ValueError: If the view is not persistent (timeout is not None) or if a component's
-                       custom_id is already registered.
-       """
-       if self.is_ready():
-           print(
-               "Warning: Adding a persistent view after the client is ready. "
-               "This view will only be available for interactions on this session."
-           )
+        Raises:
+            ValueError: If the view is not persistent (timeout is not None) or if a component's
+                        custom_id is already registered.
+        """
+        if self.is_ready():
+            print(
+                "Warning: Adding a persistent view after the client is ready. "
+                "This view will only be available for interactions on this session."
+            )
 
-       if view.timeout is not None:
-           raise ValueError("Persistent views must have a timeout of None.")
+        if view.timeout is not None:
+            raise ValueError("Persistent views must have a timeout of None.")
 
-       for item in view.children:
-           if item.custom_id:  # Ensure custom_id is not None
-               if item.custom_id in self._persistent_views:
-                   raise ValueError(
-                       f"A component with custom_id '{item.custom_id}' is already registered."
-                   )
-               self._persistent_views[item.custom_id] = view
+        for item in view.children:
+            if item.custom_id:  # Ensure custom_id is not None
+                if item.custom_id in self._persistent_views:
+                    raise ValueError(
+                        f"A component with custom_id '{item.custom_id}' is already registered."
+                    )
+                self._persistent_views[item.custom_id] = view
 
     # --- Application Command Methods ---
     async def process_interaction(self, interaction: Interaction) -> None:

--- a/disagreement/error_handler.py
+++ b/disagreement/error_handler.py
@@ -14,7 +14,11 @@ def setup_global_error_handler(
     The handler logs unhandled exceptions so they don't crash the bot.
     """
     if loop is None:
-        loop = asyncio.get_event_loop()
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
 
     if not logging.getLogger().hasHandlers():
         setup_logging(logging.ERROR)

--- a/tests/test_gateway_backoff.py
+++ b/tests/test_gateway_backoff.py
@@ -24,7 +24,7 @@ class DummyDispatcher:
 
 class DummyClient:
     def __init__(self):
-        self.loop = asyncio.get_event_loop()
+        self.loop = asyncio.get_running_loop()
         self.application_id = None  # Mock application_id for Client.connect
 
 
@@ -39,7 +39,7 @@ async def test_client_connect_backoff(monkeypatch):
     client = Client(
         token="test_token",
         intents=0,
-        loop=asyncio.get_event_loop(),
+        loop=asyncio.get_running_loop(),
         command_prefix="!",
         verbose=False,
         mention_replies=False,


### PR DESCRIPTION
## Summary
- use `asyncio.get_running_loop()` with fallback to `asyncio.new_event_loop()`
- update docstrings and tests for new loop logic

## Testing
- `pyright`
- `pylint --disable=all --enable=E,F disagreement tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684940a3c75c83239188ccb1dfcd332d