### PR TITLE
Add default allowed_mentions setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,20 @@ These options are forwarded to ``HTTPClient`` when it creates the underlying
 ``aiohttp.ClientSession``. You can specify a custom ``connector`` or any other
 session parameter supported by ``aiohttp``.
 
+### Default Allowed Mentions
+
+Specify default mention behaviour for all outgoing messages when constructing the client:
+
+```python
+client = disagreement.Client(
+    token=token,
+    allowed_mentions={"parse": [], "replied_user": False},
+)
+```
+
+This dictionary is used whenever ``send_message`` is called without an explicit
+``allowed_mentions`` argument.
+
 ### Defining Subcommands with `AppCommandGroup`
 
 ```python

--- a/docs/mentions.md
+++ b/docs/mentions.md
@@ -1,0 +1,23 @@
+# Controlling Mentions
+
+The client exposes settings to control how mentions behave in outgoing messages.
+
+## Default Allowed Mentions
+
+Use the ``allowed_mentions`` parameter of :class:`disagreement.Client` to set a
+default for all messages:
+
+```python
+client = disagreement.Client(
+    token="YOUR_TOKEN",
+    allowed_mentions={"parse": [], "replied_user": False},
+)
+```
+
+When ``Client.send_message`` is called without an explicit ``allowed_mentions``
+argument this value will be used.
+
+## Next Steps
+
+- [Commands](commands.md)
+- [HTTP Client Options](http_client.md)


### PR DESCRIPTION
## Summary
- add `allowed_mentions` option to `Client.__init__`
- use the client default when `send_message` has no `allowed_mentions`
- document mention control in README
- add new docs page for mention settings

## Testing
- `pyright`
- `pylint disagreement/client.py --disable=all --enable=E,F`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849410c4070832396f045d09023b7b7