### PR TITLE
Add Activity presence model

### DIFF
--- a/disagreement/client.py
+++ b/disagreement/client.py
@@ -36,6 +36,7 @@ from .ext import loader as ext_loader
 from .interactions import Interaction, Snowflake
 from .error_handler import setup_global_error_handler
 from .voice_client import VoiceClient
+from .models import Activity
 
 if TYPE_CHECKING:
     from .models import (
@@ -435,8 +436,7 @@ class Client:
     async def change_presence(
         self,
         status: str,
-        activity_name: Optional[str] = None,
-        activity_type: int = 0,
+        activity: Optional[Activity] = None,
         since: int = 0,
         afk: bool = False,
     ):
@@ -445,8 +445,7 @@ class Client:
 
         Args:
             status (str): The new status for the client (e.g., "online", "idle", "dnd", "invisible").
-            activity_name (Optional[str]): The name of the activity.
-            activity_type (int): The type of the activity.
+            activity (Optional[Activity]): Activity instance describing what the bot is doing.
             since (int): The timestamp (in milliseconds) of when the client went idle.
             afk (bool): Whether the client is AFK.
         """
@@ -456,8 +455,7 @@ class Client:
         if self._gateway:
             await self._gateway.update_presence(
                 status=status,
-                activity_name=activity_name,
-                activity_type=activity_type,
+                activity=activity,
                 since=since,
                 afk=afk,
             )
@@ -693,7 +691,7 @@ class Client:
             )
             # import traceback
             # traceback.print_exception(type(error.original), error.original, error.original.__traceback__)
- 
+
     async def on_command_completion(self, ctx: "CommandContext") -> None:
         """
         Default command completion handler. Called when a command has successfully completed.
@@ -1514,35 +1512,35 @@ class Client:
         return [self.parse_invite(inv) for inv in data]
 
     def add_persistent_view(self, view: "View") -> None:
-       """
-       Registers a persistent view with the client.
+        """
+        Registers a persistent view with the client.
 
-       Persistent views have a timeout of `None` and their components must have a `custom_id`.
-       This allows the view to be re-instantiated across bot restarts.
+        Persistent views have a timeout of `None` and their components must have a `custom_id`.
+        This allows the view to be re-instantiated across bot restarts.
 
-       Args:
-           view (View): The view instance to register.
+        Args:
+            view (View): The view instance to register.
 
-       Raises:
-           ValueError: If the view is not persistent (timeout is not None) or if a component's
-                       custom_id is already registered.
-       """
-       if self.is_ready():
-           print(
-               "Warning: Adding a persistent view after the client is ready. "
-               "This view will only be available for interactions on this session."
-           )
+        Raises:
+            ValueError: If the view is not persistent (timeout is not None) or if a component's
+                        custom_id is already registered.
+        """
+        if self.is_ready():
+            print(
+                "Warning: Adding a persistent view after the client is ready. "
+                "This view will only be available for interactions on this session."
+            )
 
-       if view.timeout is not None:
-           raise ValueError("Persistent views must have a timeout of None.")
+        if view.timeout is not None:
+            raise ValueError("Persistent views must have a timeout of None.")
 
-       for item in view.children:
-           if item.custom_id:  # Ensure custom_id is not None
-               if item.custom_id in self._persistent_views:
-                   raise ValueError(
-                       f"A component with custom_id '{item.custom_id}' is already registered."
-                   )
-               self._persistent_views[item.custom_id] = view
+        for item in view.children:
+            if item.custom_id:  # Ensure custom_id is not None
+                if item.custom_id in self._persistent_views:
+                    raise ValueError(
+                        f"A component with custom_id '{item.custom_id}' is already registered."
+                    )
+                self._persistent_views[item.custom_id] = view
 
     # --- Application Command Methods ---
     async def process_interaction(self, interaction: Interaction) -> None:

--- a/disagreement/gateway.py
+++ b/disagreement/gateway.py
@@ -14,6 +14,8 @@ import time
 import random
 from typing import Optional, TYPE_CHECKING, Any, Dict
 
+from .models import Activity
+
 from .enums import GatewayOpcode, GatewayIntent
 from .errors import GatewayException, DisagreementException, AuthenticationError
 from .interactions import Interaction
@@ -213,26 +215,17 @@ class GatewayClient:
     async def update_presence(
         self,
         status: str,
-        activity_name: Optional[str] = None,
-        activity_type: int = 0,
+        activity: Optional[Activity] = None,
+        *,
         since: int = 0,
         afk: bool = False,
-    ):
+    ) -> None:
         """Sends the presence update payload to the Gateway."""
         payload = {
             "op": GatewayOpcode.PRESENCE_UPDATE,
             "d": {
                 "since": since,
-                "activities": (
-                    [
-                        {
-                            "name": activity_name,
-                            "type": activity_type,
-                        }
-                    ]
-                    if activity_name
-                    else []
-                ),
+                "activities": [activity.to_dict()] if activity else [],
                 "status": status,
                 "afk": afk,
             },
@@ -353,7 +346,10 @@ class GatewayClient:
                         future._members.extend(raw_event_d_payload.get("members", []))  # type: ignore
 
                         # If this is the last chunk, resolve the future
-                        if raw_event_d_payload.get("chunk_index") == raw_event_d_payload.get("chunk_count", 1) - 1:
+                        if (
+                            raw_event_d_payload.get("chunk_index")
+                            == raw_event_d_payload.get("chunk_count", 1) - 1
+                        ):
                             future.set_result(future._members)  # type: ignore
                             del self._member_chunk_requests[nonce]
 

--- a/docs/presence.md
+++ b/docs/presence.md
@@ -1,6 +1,7 @@
 # Updating Presence
 
 The `Client.change_presence` method allows you to update the bot's status and displayed activity.
+Pass an :class:`~disagreement.models.Activity` (such as :class:`~disagreement.models.Game` or :class:`~disagreement.models.Streaming`) to describe what your bot is doing.
 
 ## Status Strings
 
@@ -22,8 +23,18 @@ An activity dictionary must include a `name` and a `type` field. The type value 
 | `4`  | Custom       |
 | `5`  | Competing    |
 
-Example:
+Example using the provided activity classes:
 
 ```python
-await client.change_presence(status="idle", activity={"name": "with Discord", "type": 0})
+from disagreement.models import Game
+
+await client.change_presence(status="idle", activity=Game("with Discord"))
+```
+
+You can also specify a streaming URL:
+
+```python
+from disagreement.models import Streaming
+
+await client.change_presence(status="online", activity=Streaming("My Stream", "https://twitch.tv/someone"))
 ```

--- a/tests/test_presence_update.py
+++ b/tests/test_presence_update.py
@@ -2,6 +2,7 @@ import pytest
 from unittest.mock import AsyncMock
 
 from disagreement.client import Client
+from disagreement.models import Game
 from disagreement.errors import DisagreementException
 
 
@@ -18,11 +19,11 @@ class DummyGateway(MagicMock):
 async def test_change_presence_passes_arguments():
     client = Client(token="t")
     client._gateway = DummyGateway()
-
-    await client.change_presence(status="idle", activity_name="hi", activity_type=0)
+    game = Game("hi")
+    await client.change_presence(status="idle", activity=game)
 
     client._gateway.update_presence.assert_awaited_once_with(
-        status="idle", activity_name="hi", activity_type=0, since=0, afk=False
+        status="idle", activity=game, since=0, afk=False
     )
 
 


### PR DESCRIPTION
## Summary
- add `Activity` class hierarchy in `models`
- update gateway and client to use the new models
- document activities in `docs/presence.md`
- adjust presence tests for new API

## Testing
- `pylint --disable=all --enable=E,F disagreement`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849412a50cc8323b474fca5248d37e3