### PR TITLE
Add AutoArchiveDuration enum and thread improvements

### DIFF
--- a/disagreement/enums.py
+++ b/disagreement/enums.py
@@ -375,6 +375,15 @@ class OverwriteType(IntEnum):
     MEMBER = 1
 
 
+class AutoArchiveDuration(IntEnum):
+    """Thread auto-archive duration in minutes."""
+
+    HOUR = 60
+    DAY = 1440
+    THREE_DAYS = 4320
+    WEEK = 10080
+
+
 # --- Component Enums ---
 
 

--- a/docs/threads.md
+++ b/docs/threads.md
@@ -1,0 +1,18 @@
+# Threads
+
+`Message.create_thread` and `TextChannel.create_thread` let you start new threads.
+Use :class:`AutoArchiveDuration` to control when a thread is automatically archived.
+
+```python
+from disagreement.enums import AutoArchiveDuration
+
+await message.create_thread(
+    "discussion",
+    auto_archive_duration=AutoArchiveDuration.DAY,
+)
+```
+
+## Next Steps
+
+- [Message History](message_history.md)
+- [Caching](caching.md)


### PR DESCRIPTION
## Summary
- add `AutoArchiveDuration` enum for valid thread archive durations
- update thread creation APIs to use the new enum
- document auto-archive durations in new `threads.md`

## Testing
- `pyright`
- `pylint --disable=all --enable=E,F disagreement/enums.py disagreement/models.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849414ebbb88323a68975687f08c2fc