### PR TITLE
Remove obsolete comments

### DIFF
--- a/disagreement/__init__.py
+++ b/disagreement/__init__.py
@@ -1,5 +1,3 @@
-# disagreement/__init__.py
-
 """
 Disagreement
 ~~~~~~~~~~~~
@@ -31,7 +29,7 @@ from .errors import (
 )
 from .color import Color
 from .utils import utcnow, message_pager
-from .enums import GatewayIntent, GatewayOpcode  # Export enums
+from .enums import GatewayIntent, GatewayOpcode
 from .error_handler import setup_global_error_handler
 from .hybrid_context import HybridContext
 from .ext import tasks

--- a/disagreement/client.py
+++ b/disagreement/client.py
@@ -1,5 +1,3 @@
-# disagreement/client.py
-
 """
 The main Client class for interacting with the Discord API.
 """
@@ -274,7 +272,6 @@ class Client:
                     print("Max connection retries reached. Giving up.")
                     await self.close()  # Ensure cleanup
                     raise
-        # Should not be reached if max_retries is > 0
         if max_retries == 0:  # If max_retries was 0, means no retries attempted
             raise DisagreementException("Connection failed with 0 retries allowed.")
 

--- a/disagreement/enums.py
+++ b/disagreement/enums.py
@@ -1,10 +1,8 @@
-# disagreement/enums.py
-
 """
 Enums for Discord constants.
 """
 
-from enum import IntEnum, Enum  # Import Enum
+from enum import IntEnum, Enum
 
 
 class GatewayOpcode(IntEnum):

--- a/disagreement/errors.py
+++ b/disagreement/errors.py
@@ -1,10 +1,8 @@
-# disagreement/errors.py
-
 """
 Custom exceptions for the Disagreement library.
 """
 
-from typing import Optional, Any  # Add Optional and Any here
+from typing import Optional, Any
 
 
 class DisagreementException(Exception):

--- a/disagreement/event_dispatcher.py
+++ b/disagreement/event_dispatcher.py
@@ -1,5 +1,3 @@
-# disagreement/event_dispatcher.py
-
 """
 Event dispatcher for handling Discord Gateway events.
 """
@@ -198,7 +196,7 @@ class EventDispatcher:
             try:
                 self._listeners[event_name_upper].remove(coro)
             except ValueError:
-                pass  # Listener not in list
+                pass
 
     def add_waiter(
         self,

--- a/disagreement/ext/app_commands/__init__.py
+++ b/disagreement/ext/app_commands/__init__.py
@@ -1,5 +1,3 @@
-# disagreement/ext/app_commands/__init__.py
-
 """
 Application Commands Extension for Disagreement.
 

--- a/disagreement/ext/app_commands/commands.py
+++ b/disagreement/ext/app_commands/commands.py
@@ -1,5 +1,3 @@
-# disagreement/ext/app_commands/commands.py
-
 import inspect
 from typing import Any, Callable, Dict, List, Optional, Union, TYPE_CHECKING
 

--- a/disagreement/ext/app_commands/context.py
+++ b/disagreement/ext/app_commands/context.py
@@ -1,5 +1,3 @@
-# disagreement/ext/app_commands/context.py
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional, List, Union, Any, Dict

--- a/disagreement/ext/app_commands/converters.py
+++ b/disagreement/ext/app_commands/converters.py
@@ -1,5 +1,3 @@
-# disagreement/ext/app_commands/converters.py
-
 """
 Converters for transforming application command option values.
 """
@@ -466,8 +464,8 @@ async def run_converters(
 
     # If no specific converter, and it's not a basic type match, raise error or return raw
     # For now, let's raise if no converter found for a specific option type
-    if option_type in DEFAULT_CONVERTERS:  # Should have been handled
-        pass  # This path implies a logic error above or missing converter in DEFAULT_CONVERTERS
+    if option_type in DEFAULT_CONVERTERS:
+        pass
 
     # If it's a model type but no converter yet, this will need to be handled
     # e.g. if param_type is User and option_type is ApplicationCommandOptionType.USER

--- a/disagreement/ext/app_commands/decorators.py
+++ b/disagreement/ext/app_commands/decorators.py
@@ -1,5 +1,3 @@
-# disagreement/ext/app_commands/decorators.py
-
 import inspect
 import asyncio
 from dataclasses import dataclass
@@ -134,7 +132,7 @@ def _extract_options_from_signature(
         first_param = next(param_iter, None)  # Consume 'self', get next
 
     if first_param and first_param.name == "ctx":  # Consume 'ctx'
-        pass  # ctx is handled, now iterate over actual command options
+        pass
     elif (
         first_param
     ):  # If first_param was not 'self' and not 'ctx', it's a command option
@@ -147,7 +145,7 @@ def _extract_options_from_signature(
         if param.kind == param.VAR_POSITIONAL or param.kind == param.VAR_KEYWORD:
             # *args and **kwargs are not directly supported by slash command options structure.
             # Could raise an error or ignore. For now, ignore.
-            # print(f"Warning: *args/**kwargs ({param.name}) are not supported for slash command options.")
+
             continue
 
         option_name = param.name
@@ -190,7 +188,7 @@ def _extract_options_from_signature(
                 # More complex Unions are not directly supported by a single option type.
                 # Could default to STRING or raise.
                 # For now, let's assume simple Optional[T] or direct types.
-                # print(f"Warning: Complex Union type for '{option_name}' not fully supported, defaulting to STRING.")
+
                 actual_type_for_mapping = str
 
         elif origin is list and len(args) == 1:
@@ -198,7 +196,7 @@ def _extract_options_from_signature(
             # via repeated options or specific component interactions, not directly in slash command options.
             # This might indicate a need for a different interaction pattern or custom parsing.
             # For now, treat List[str] as a string, others might error or default.
-            # print(f"Warning: List type for '{option_name}' not directly supported as a single option. Consider type {args[0]}.")
+
             actual_type_for_mapping = args[
                 0
             ]  # Use the inner type for mapping, but this is a simplification.
@@ -247,7 +245,7 @@ def _extract_options_from_signature(
 
         if not option_type:
             # Fallback or error if type couldn't be mapped
-            # print(f"Warning: Could not map type '{actual_type_for_mapping}' for option '{option_name}'. Defaulting to STRING.")
+
             option_type = ApplicationCommandOptionType.STRING  # Default fallback
 
         required = (param.default == inspect.Parameter.empty) and not is_optional

--- a/disagreement/ext/app_commands/handler.py
+++ b/disagreement/ext/app_commands/handler.py
@@ -1,5 +1,3 @@
-# disagreement/ext/app_commands/handler.py
-
 import inspect
 import json
 import logging
@@ -341,7 +339,7 @@ class AppCommandHandler:
                     return value.lower() == "true"
                 return bool(value)
         except (ValueError, TypeError):
-            pass  # Conversion failed
+            pass
         return value  # Return as is if no specific resolution or conversion applied
 
     async def _resolve_value(

--- a/disagreement/ext/app_commands/hybrid.py
+++ b/disagreement/ext/app_commands/hybrid.py
@@ -1,5 +1,3 @@
-# disagreement/ext/app_commands/hybrid.py
-
 from typing import Any, Callable, List, Optional
 
 from .commands import SlashCommand

--- a/disagreement/ext/commands/__init__.py
+++ b/disagreement/ext/commands/__init__.py
@@ -1,5 +1,3 @@
-# disagreement/ext/commands/__init__.py
-
 """
 disagreement.ext.commands - A command framework extension for the Disagreement library.
 """

--- a/disagreement/ext/commands/cog.py
+++ b/disagreement/ext/commands/cog.py
@@ -1,5 +1,3 @@
-# disagreement/ext/commands/cog.py
-
 import inspect
 import logging
 from typing import TYPE_CHECKING, List, Tuple, Callable, Awaitable, Any, Dict, Union

--- a/disagreement/ext/commands/converters.py
+++ b/disagreement/ext/commands/converters.py
@@ -1,4 +1,3 @@
-# disagreement/ext/commands/converters.py
 # pyright: reportIncompatibleMethodOverride=false
 
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, TypeVar, Generic

--- a/disagreement/ext/commands/core.py
+++ b/disagreement/ext/commands/core.py
@@ -1,5 +1,3 @@
-# disagreement/ext/commands/core.py
-
 from __future__ import annotations
 
 import asyncio
@@ -567,9 +565,7 @@ class CommandHandler:
 
                 # If final_value_for_param was not set by greedy logic, try conversion
                 if final_value_for_param is inspect.Parameter.empty:
-                    if (
-                        arg_str_value is None
-                    ):  # Should not happen if view.get_word/get_quoted_string is robust
+                    if arg_str_value is None:
                         if param.default is not inspect.Parameter.empty:
                             final_value_for_param = param.default
                         else:
@@ -609,7 +605,7 @@ class CommandHandler:
                                     final_value_for_param = None
                                 elif last_err_union:
                                     raise last_err_union
-                                else:  # Should not be reached if logic is correct
+                                else:
                                     raise BadArgument(
                                         f"Could not convert '{arg_str_value}' to any of {union_args} for param '{param.name}'."
                                     )

--- a/disagreement/ext/commands/decorators.py
+++ b/disagreement/ext/commands/decorators.py
@@ -1,4 +1,3 @@
-# disagreement/ext/commands/decorators.py
 from __future__ import annotations
 
 import asyncio

--- a/disagreement/ext/commands/errors.py
+++ b/disagreement/ext/commands/errors.py
@@ -1,5 +1,3 @@
-# disagreement/ext/commands/errors.py
-
 """
 Custom exceptions for the command extension.
 """

--- a/disagreement/ext/commands/help.py
+++ b/disagreement/ext/commands/help.py
@@ -1,5 +1,3 @@
-# disagreement/ext/commands/help.py
-
 from typing import List, Optional
 
 from .core import Command, CommandContext, CommandHandler

--- a/disagreement/ext/commands/view.py
+++ b/disagreement/ext/commands/view.py
@@ -1,5 +1,3 @@
-# disagreement/ext/commands/view.py
-
 import re
 
 
@@ -47,7 +45,7 @@ class StringView:
             word = match.group(0)
             self.index += len(word)
             return word
-        return ""  # Should not happen if not eof and skip_whitespace was called
+        return ""
 
     def get_quoted_string(self) -> str:
         """

--- a/disagreement/gateway.py
+++ b/disagreement/gateway.py
@@ -1,5 +1,3 @@
-# disagreement/gateway.py
-
 """
 Manages the WebSocket connection to the Discord Gateway.
 """
@@ -152,12 +150,11 @@ class GatewayClient:
         self._last_heartbeat_sent = time.monotonic()
         payload = {"op": GatewayOpcode.HEARTBEAT, "d": self._last_sequence}
         await self._send_json(payload)
-        # print("Sent heartbeat.")
 
     async def _keep_alive(self):
         """Manages the heartbeating loop."""
         if self._heartbeat_interval is None:
-            # This should not happen if HELLO was processed correctly
+
             logger.error("Heartbeat interval not set. Cannot start keep_alive.")
             return
 
@@ -358,7 +355,7 @@ class GatewayClient:
                             del self._member_chunk_requests[nonce]
 
         elif event_name == "INTERACTION_CREATE":
-            # print(f"GATEWAY RECV INTERACTION_CREATE: {raw_event_d_payload}")
+
             if isinstance(raw_event_d_payload, dict):
                 interaction = Interaction(
                     data=raw_event_d_payload, client_instance=self._client_instance
@@ -397,7 +394,7 @@ class GatewayClient:
             event_data_to_dispatch = (
                 raw_event_d_payload if isinstance(raw_event_d_payload, dict) else {}
             )
-            # print(f"GATEWAY RECV EVENT: {event_name} | DATA: {event_data_to_dispatch}")
+
             await self._dispatcher.dispatch(event_name, event_data_to_dispatch)
         else:
             logger.warning("Received dispatch with no event name: %s", data)
@@ -496,8 +493,6 @@ class GatewayClient:
                 await self._identify()
         elif op == GatewayOpcode.HEARTBEAT_ACK:
             self._last_heartbeat_ack = time.monotonic()
-            # print("Received heartbeat ACK.")
-            pass  # Good, connection is alive
         else:
             logger.warning(
                 "Received unhandled Gateway Opcode: %s with data: %s", op, data
@@ -584,7 +579,7 @@ class GatewayClient:
             try:
                 await self._keep_alive_task
             except asyncio.CancelledError:
-                pass  # Expected
+                pass
 
         if self._receive_task and not self._receive_task.done():
             current = asyncio.current_task(loop=self._loop)
@@ -593,7 +588,7 @@ class GatewayClient:
                 try:
                     await self._receive_task
                 except asyncio.CancelledError:
-                    pass  # Expected
+                    pass
 
         if self._ws and not self._ws.closed:
             await self._ws.close(code=code)

--- a/disagreement/http.py
+++ b/disagreement/http.py
@@ -1,5 +1,3 @@
-# disagreement/http.py
-
 """
 HTTP client for interacting with the Discord REST API.
 """
@@ -447,8 +445,6 @@ class HTTPClient:
                     text=error_text,
                     error_code=discord_error_code,
                 )
-
-        # Should not be reached if retries are exhausted by RateLimitError
         raise DisagreementException(
             f"Failed request to {method} {endpoint} after multiple retries."
         )

--- a/disagreement/interactions.py
+++ b/disagreement/interactions.py
@@ -1,5 +1,3 @@
-# disagreement/interactions.py
-
 """
 Data models for Discord Interaction objects.
 """

--- a/disagreement/models.py
+++ b/disagreement/models.py
@@ -1,5 +1,3 @@
-# disagreement/models.py
-
 """
 Data models for Discord objects.
 """
@@ -714,7 +712,7 @@ class Member(User):  # Member inherits from User
             # We'd need to construct a partial user from top-level member fields if 'user' is missing.
             # For now, assume 'user' object is present for full Member hydration.
             # If 'user' is missing, the User part might be incomplete.
-            pass  # User fields will be missing or default if 'user' not in data.
+            pass
 
         super().__init__(
             user_data if user_data else data

--- a/disagreement/shard_manager.py
+++ b/disagreement/shard_manager.py
@@ -1,5 +1,3 @@
-# disagreement/shard_manager.py
-
 """Sharding utilities for managing multiple gateway connections."""
 
 from __future__ import annotations

--- a/disagreement/ui/view.py
+++ b/disagreement/ui/view.py
@@ -147,7 +147,7 @@ class View:
 
     async def on_timeout(self):
         """Called when the view times out."""
-        pass  # User can override this
+        pass
 
     async def _start(self, client: Client):
         """Starts the view's internal listener."""

--- a/disagreement/voice_client.py
+++ b/disagreement/voice_client.py
@@ -1,4 +1,3 @@
-# disagreement/voice_client.py
 """Voice gateway and UDP audio client."""
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- drop leftover header comments from modules
- clean up stray debug and placeholder comments

## Testing
- `pyright`
- `pylint disagreement --disable=all --enable=E,F`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684a02c370988323a2bbf58a14e32c6c