### PR TITLE
Add Message.jump_url helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A Python library for interacting with the Discord API, with a focus on bot devel
 - Gateway and HTTP API clients
 - Slash command framework
 - Message component helpers
+- `Message.jump_url` property for quick links to messages
 - Built-in caching layer
 - Experimental voice support
 - Helpful error handling utilities

--- a/disagreement/models.py
+++ b/disagreement/models.py
@@ -116,6 +116,13 @@ class Message:
         # self.mention_everyone: bool = data.get("mention_everyone", False)
 
     @property
+    def jump_url(self) -> str:
+        """Return a URL that jumps to this message in the Discord client."""
+
+        guild_or_dm = self.guild_id or "@me"
+        return f"https://discord.com/channels/{guild_or_dm}/{self.channel_id}/{self.id}"
+
+    @property
     def clean_content(self) -> str:
         """Returns message content without user, role, or channel mentions."""
 

--- a/docs/message_history.md
+++ b/docs/message_history.md
@@ -8,6 +8,9 @@ async for message in channel.history(limit=200):
     print(message.content)
 ```
 
+Each returned `Message` has a ``jump_url`` property that links directly to the
+message in the Discord client.
+
 Pass `before` or `after` to control the range of messages returned. The paginator fetches messages in batches of up to 100 until the limit is reached or Discord returns no more messages.
 
 ## Next Steps


### PR DESCRIPTION
## Summary
- add `jump_url` property to `Message`
- document the new property in README and docs

## Testing
- `black disagreement`
- `pylint disagreement --disable=all --enable=E,F -rn` (no output)
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a15ce5b4c8323a42517ee352928f9