### PR TITLE
Add listener helper methods

### DIFF
--- a/disagreement/client.py
+++ b/disagreement/client.py
@@ -539,6 +539,20 @@ class Client:
 
         return decorator
 
+    def add_listener(
+        self, event_name: str, coro: Callable[..., Awaitable[None]]
+    ) -> None:
+        """Register ``coro`` to listen for ``event_name``."""
+
+        self._event_dispatcher.register(event_name, coro)
+
+    def remove_listener(
+        self, event_name: str, coro: Callable[..., Awaitable[None]]
+    ) -> None:
+        """Remove ``coro`` from ``event_name`` listeners."""
+
+        self._event_dispatcher.unregister(event_name, coro)
+
     async def _process_message_for_commands(self, message: "Message") -> None:
         """Internal listener to process messages for commands."""
         # Make sure message object is valid and not from a bot (optional, common check)

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,7 +1,7 @@
 # Events
 
-Disagreement dispatches Gateway events to asynchronous callbacks. Handlers can be registered with `@client.event` or `client.on_event`.
-Listeners may be removed later using `EventDispatcher.unregister(event_name, coro)`.
+Disagreement dispatches Gateway events to asynchronous callbacks. Handlers can be registered with `@client.event`, `client.on_event`, or `client.add_listener(event_name, coro)`.
+Listeners may be removed later using `client.remove_listener(event_name, coro)` or `EventDispatcher.unregister(event_name, coro)`.
 
 ## Raw Events
 


### PR DESCRIPTION
## Summary
- add `Client.add_listener` and `Client.remove_listener`
- document event helper methods

## Testing
- `pyright`
- `pylint --disable=all --enable=E,F disagreement/client.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a15cf27c08323a8819809f985d10d