### PR TITLE
Add AllowedMentions helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,10 @@ session parameter supported by ``aiohttp``.
 Specify default mention behaviour for all outgoing messages when constructing the client:
 
 ```python
+from disagreement.models import AllowedMentions
 client = disagreement.Client(
     token=token,
-    allowed_mentions={"parse": [], "replied_user": False},
+    allowed_mentions=AllowedMentions.none().to_dict(),
 )
 ```
 

--- a/disagreement/models.py
+++ b/disagreement/models.py
@@ -633,6 +633,23 @@ class AllowedMentions:
         self.users: List[str] = data.get("users", [])
         self.replied_user: bool = data.get("replied_user", False)
 
+    @classmethod
+    def all(cls) -> "AllowedMentions":
+        """Return an instance allowing all mention types."""
+
+        return cls(
+            {
+                "parse": ["users", "roles", "everyone"],
+                "replied_user": True,
+            }
+        )
+
+    @classmethod
+    def none(cls) -> "AllowedMentions":
+        """Return an instance disallowing all mentions."""
+
+        return cls({"parse": [], "replied_user": False})
+
     def to_dict(self) -> Dict[str, Any]:
         payload: Dict[str, Any] = {"parse": self.parse}
         if self.roles:

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -118,14 +118,18 @@ session parameter supported by ``aiohttp``.
 Specify default mention behaviour for all outgoing messages when constructing the client:
 
 ```python
+from disagreement.models import AllowedMentions
 client = disagreement.Client(
     token=token,
-    allowed_mentions={"parse": [], "replied_user": False},
+    allowed_mentions=AllowedMentions.none().to_dict(),
 )
 ```
 
 This dictionary is used whenever ``send_message`` is called without an explicit
 ``allowed_mentions`` argument.
+
+The :class:`AllowedMentions` class offers ``none()`` and ``all()`` helpers for
+quickly generating these configurations.
 
 ### Defining Subcommands with `AppCommandGroup`
 

--- a/docs/mentions.md
+++ b/docs/mentions.md
@@ -8,14 +8,19 @@ Use the ``allowed_mentions`` parameter of :class:`disagreement.Client` to set a
 default for all messages:
 
 ```python
+from disagreement.models import AllowedMentions
 client = disagreement.Client(
     token="YOUR_TOKEN",
-    allowed_mentions={"parse": [], "replied_user": False},
+    allowed_mentions=AllowedMentions.none().to_dict(),
 )
 ```
 
 When ``Client.send_message`` is called without an explicit ``allowed_mentions``
 argument this value will be used.
+
+``AllowedMentions`` also provides the convenience methods
+``AllowedMentions.none()`` and ``AllowedMentions.all()`` to quickly create
+common configurations.
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary
- implement `AllowedMentions.all()` and `AllowedMentions.none()`
- document helper usage in README and docs

## Testing
- `pyright`
- `pylint --disable=all --enable=E,F disagreement/models.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a15d054a88323b371fd4561addc48