### PR TITLE
Fix export list

### DIFF
--- a/disagreement/__init__.py
+++ b/disagreement/__init__.py
@@ -38,6 +38,35 @@ from .logging_config import setup_logging
 import logging
 
 
+__all__ = [
+    "Client",
+    "AutoShardedClient",
+    "Message",
+    "User",
+    "Reaction",
+    "AuditLogEntry",
+    "VoiceClient",
+    "AudioSource",
+    "FFmpegAudioSource",
+    "Typing",
+    "DisagreementException",
+    "HTTPException",
+    "GatewayException",
+    "AuthenticationError",
+    "Forbidden",
+    "NotFound",
+    "Color",
+    "utcnow",
+    "message_pager",
+    "GatewayIntent",
+    "GatewayOpcode",
+    "setup_global_error_handler",
+    "HybridContext",
+    "tasks",
+    "setup_logging",
+]
+
+
 # Configure a default logger if none has been configured yet
 if not logging.getLogger().hasHandlers():
     setup_logging(logging.INFO)


### PR DESCRIPTION
## Summary
- expose Client and other public symbols via `__all__`

## Testing
- `pyright`
- `pylint disagreement/__init__.py --disable=all --enable=E,F`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b99ef686c8323bcb4878f8cbb081d