### PR TITLE
Implement global allowed_mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ client = disagreement.Client(
 )
 ```
 
-This dictionary is used whenever ``send_message`` is called without an explicit
-``allowed_mentions`` argument.
+This dictionary is used whenever ``send_message`` or helpers like ``Message.reply``
+are called without an explicit ``allowed_mentions`` argument.
 
 ### Defining Subcommands with `AppCommandGroup`
 

--- a/disagreement/ext/app_commands/context.py
+++ b/disagreement/ext/app_commands/context.py
@@ -253,6 +253,8 @@ class AppCommandContext:
             Optional[Message]: The sent message object if a new message was created and not ephemeral.
                                None if the response was ephemeral or an edit to a deferred message.
         """
+        if allowed_mentions is None:
+            allowed_mentions = getattr(self.bot, "allowed_mentions", None)
         if not self._responded and self._deferred:  # Editing a deferred response
             # Use edit_original_interaction_response
             payload: Dict[str, Any] = {}
@@ -393,6 +395,9 @@ class AppCommandContext:
                 "Must acknowledge or defer the interaction before sending a followup."
             )
 
+        if allowed_mentions is None:
+            allowed_mentions = getattr(self.bot, "allowed_mentions", None)
+
         payload: Dict[str, Any] = {}
         if content is not None:
             payload["content"] = content
@@ -472,6 +477,9 @@ class AppCommandContext:
             raise RuntimeError(
                 "Cannot edit response if interaction hasn't been responded to or deferred."
             )
+
+        if allowed_mentions is None:
+            allowed_mentions = getattr(self.bot, "allowed_mentions", None)
 
         payload: Dict[str, Any] = {}
         if content is not None:

--- a/disagreement/ext/commands/core.py
+++ b/disagreement/ext/commands/core.py
@@ -255,10 +255,10 @@ class CommandContext:
             mention_author = getattr(self.bot, "mention_replies", False)
 
         if allowed_mentions is None:
-            allowed_mentions = {"replied_user": mention_author}
+            allowed_mentions = dict(getattr(self.bot, "allowed_mentions", {}) or {})
         else:
             allowed_mentions = dict(allowed_mentions)
-            allowed_mentions.setdefault("replied_user", mention_author)
+        allowed_mentions.setdefault("replied_user", mention_author)
 
         return await self.bot.send_message(
             channel_id=self.message.channel_id,

--- a/disagreement/models.py
+++ b/disagreement/models.py
@@ -198,10 +198,10 @@ class Message:
             mention_author = getattr(self._client, "mention_replies", False)
 
         if allowed_mentions is None:
-            allowed_mentions = {"replied_user": mention_author}
+            allowed_mentions = dict(getattr(self._client, "allowed_mentions", {}) or {})
         else:
             allowed_mentions = dict(allowed_mentions)
-            allowed_mentions.setdefault("replied_user", mention_author)
+        allowed_mentions.setdefault("replied_user", mention_author)
 
         # Client.send_message is already updated to handle these parameters
         return await self._client.send_message(

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -125,8 +125,8 @@ client = disagreement.Client(
 )
 ```
 
-This dictionary is used whenever ``send_message`` is called without an explicit
-``allowed_mentions`` argument.
+This dictionary is used whenever ``send_message`` or helpers like ``Message.reply``
+are called without an explicit ``allowed_mentions`` argument.
 
 The :class:`AllowedMentions` class offers ``none()`` and ``all()`` helpers for
 quickly generating these configurations.

--- a/docs/mentions.md
+++ b/docs/mentions.md
@@ -15,7 +15,8 @@ client = disagreement.Client(
 )
 ```
 
-When ``Client.send_message`` is called without an explicit ``allowed_mentions``
+When ``Client.send_message`` or convenience methods like ``Message.reply`` and
+``CommandContext.reply`` are called without an explicit ``allowed_mentions``
 argument this value will be used.
 
 ``AllowedMentions`` also provides the convenience methods


### PR DESCRIPTION
## Summary
- rely on `Client.allowed_mentions` when replying in models and command contexts
- default `allowed_mentions` for app command responses
- update docs about allowed mentions behavior

## Testing
- `pylint --disable=all --enable=E,F disagreement | tail -n 20`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c70e99a6c8323b38bdcf8dc8eceb7