### PR TITLE
Fix gateway runtime errors

### DIFF
--- a/disagreement/enums.py
+++ b/disagreement/enums.py
@@ -273,7 +273,12 @@ class GuildFeature(str, Enum):  # Changed from IntEnum to Enum
     # This allows GuildFeature("UNKNOWN_FEATURE_STRING") to work
     @classmethod
     def _missing_(cls, value):  # type: ignore
-        return str(value)
+        member = object.__new__(cls)
+        member._name_ = str(value)
+        member._value_ = str(value)
+        cls._value2member_map_[member._value_] = member  # pylint: disable=no-member
+        cls._member_map_[member._name_] = member  # pylint: disable=no-member
+        return member
 
 
 # --- Guild Scheduled Event Enums ---
@@ -329,7 +334,12 @@ class VoiceRegion(str, Enum):
 
     @classmethod
     def _missing_(cls, value):  # type: ignore
-        return str(value)
+        member = object.__new__(cls)
+        member._name_ = str(value)
+        member._value_ = str(value)
+        cls._value2member_map_[member._value_] = member  # pylint: disable=no-member
+        cls._member_map_[member._name_] = member  # pylint: disable=no-member
+        return member
 
 
 # --- Channel Enums ---

--- a/disagreement/ext/app_commands/handler.py
+++ b/disagreement/ext/app_commands/handler.py
@@ -587,12 +587,19 @@ class AppCommandHandler:
             #         print(f"Failed to send error message for app command: {send_e}")
 
     async def sync_commands(
-        self, application_id: "Snowflake", guild_id: Optional["Snowflake"] = None
+        self,
+        application_id: Optional["Snowflake"] = None,
+        guild_id: Optional["Snowflake"] = None,
     ) -> None:
         """
         Synchronizes (registers/updates) all application commands with Discord.
         If guild_id is provided, syncs commands for that guild. Otherwise, syncs global commands.
         """
+        if application_id is None:
+            application_id = self.client.application_id
+        if application_id is None:
+            raise ValueError("application_id must be provided to sync commands")
+
         cache = self._load_cached_ids()
         scope_key = str(guild_id) if guild_id else "global"
         stored = cache.get(scope_key, {})

--- a/disagreement/http.py
+++ b/disagreement/http.py
@@ -1364,3 +1364,8 @@ class HTTPClient:
     async def leave_thread(self, channel_id: "Snowflake") -> None:
         """Removes the current user from a thread."""
         await self.request("DELETE", f"/channels/{channel_id}/thread-members/@me")
+
+    async def create_dm(self, recipient_id: "Snowflake") -> Dict[str, Any]:
+        """Creates (or opens) a DM channel with the given user."""
+        payload = {"recipient_id": str(recipient_id)}
+        return await self.request("POST", "/users/@me/channels", payload=payload)


### PR DESCRIPTION
## Summary
- default AppCommandHandler.sync_commands to use client application ID
- add DM creation utilities and support `User.send`
- relax enum parsing for unknown values
- allow partial user data in presence updates

## Testing
- `pylint --disable=all --enable=E,F disagreement/ext/app_commands/handler.py disagreement/http.py disagreement/client.py disagreement/models.py disagreement/enums.py`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e3cede5c08323a0ceeb351d0b5f56