### PR TITLE
Add guilds property

### DIFF
--- a/disagreement/client.py
+++ b/disagreement/client.py
@@ -416,6 +416,11 @@ class Client:
         latency = getattr(self._gateway, "latency_ms", None)
         return round(latency, 2) if latency is not None else None
 
+    @property
+    def guilds(self) -> List["Guild"]:
+        """Returns all guilds from the internal cache."""
+        return self._guilds.values()
+
     async def wait_until_ready(self) -> None:
         """|coro|
         Waits until the client is fully connected to Discord and the initial state is processed.


### PR DESCRIPTION
## Summary
- add a read-only `guilds` property to return cached guilds

## Testing
- `black disagreement/client.py`
- `pylint --disable=all --enable=E,F disagreement/client.py`
- `pyright`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684e6cb6e3cc8323923496752e44382b