### PR TITLE
Add automatic command sync after READY

### DIFF
--- a/disagreement/client.py
+++ b/disagreement/client.py
@@ -90,6 +90,9 @@ class Client:
             :class:`aiohttp.ClientSession`.
         message_cache_maxlen (Optional[int]): Maximum number of messages to keep
             in the cache. When ``None``, the cache size is unlimited.
+        sync_commands_on_ready (bool): If ``True``, automatically call
+            :meth:`Client.sync_application_commands` after the ``READY`` event
+            when :attr:`Client.application_id` is available.
     """
 
     def __init__(
@@ -110,6 +113,7 @@ class Client:
         member_cache_flags: Optional[MemberCacheFlags] = None,
         message_cache_maxlen: Optional[int] = None,
         http_options: Optional[Dict[str, Any]] = None,
+        sync_commands_on_ready: bool = True,
     ):
         if not token:
             raise ValueError("A bot token must be provided.")
@@ -177,6 +181,7 @@ class Client:
         # Default whether replies mention the user
         self.mention_replies: bool = mention_replies
         self.allowed_mentions: Optional[Dict[str, Any]] = allowed_mentions
+        self.sync_commands_on_ready: bool = sync_commands_on_ready
 
         # Basic signal handling for graceful shutdown
         # This might be better handled by the user's application code, but can be a nice default.

--- a/disagreement/gateway.py
+++ b/disagreement/gateway.py
@@ -339,6 +339,12 @@ class GatewayClient:
             logger.info("Client is now marked as ready.")
 
             await self._dispatcher.dispatch(event_name, raw_event_d_payload)
+
+            if (
+                getattr(self._client_instance, "sync_commands_on_ready", True)
+                and self._client_instance.application_id
+            ):
+                asyncio.create_task(self._client_instance.sync_application_commands())
         elif event_name == "GUILD_MEMBERS_CHUNK":
             if isinstance(raw_event_d_payload, dict):
                 nonce = raw_event_d_payload.get("nonce")

--- a/tests/test_auto_sync_commands.py
+++ b/tests/test_auto_sync_commands.py
@@ -1,0 +1,83 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from disagreement.client import Client
+from disagreement.gateway import GatewayClient
+from disagreement.event_dispatcher import EventDispatcher
+
+
+class DummyHTTP:
+    pass
+
+
+class DummyUser:
+    username = "u"
+    discriminator = "0001"
+
+
+@pytest.mark.asyncio
+async def test_auto_sync_on_ready(monkeypatch):
+    client = Client(token="t", application_id="123")
+    http = DummyHTTP()
+    dispatcher = EventDispatcher(client)
+    gw = GatewayClient(
+        http_client=http,
+        event_dispatcher=dispatcher,
+        token="t",
+        intents=0,
+        client_instance=client,
+    )
+    monkeypatch.setattr(client, "parse_user", lambda d: DummyUser())
+    monkeypatch.setattr(gw._dispatcher, "dispatch", AsyncMock())
+    sync_mock = AsyncMock()
+    monkeypatch.setattr(client, "sync_application_commands", sync_mock)
+
+    data = {
+        "t": "READY",
+        "s": 1,
+        "d": {
+            "session_id": "s1",
+            "resume_gateway_url": "url",
+            "application": {"id": "123"},
+            "user": {"id": "1"},
+        },
+    }
+
+    await gw._handle_dispatch(data)
+    await asyncio.sleep(0)
+    sync_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_auto_sync_disabled(monkeypatch):
+    client = Client(token="t", application_id="123", sync_commands_on_ready=False)
+    http = DummyHTTP()
+    dispatcher = EventDispatcher(client)
+    gw = GatewayClient(
+        http_client=http,
+        event_dispatcher=dispatcher,
+        token="t",
+        intents=0,
+        client_instance=client,
+    )
+    monkeypatch.setattr(client, "parse_user", lambda d: DummyUser())
+    monkeypatch.setattr(gw._dispatcher, "dispatch", AsyncMock())
+    sync_mock = AsyncMock()
+    monkeypatch.setattr(client, "sync_application_commands", sync_mock)
+
+    data = {
+        "t": "READY",
+        "s": 1,
+        "d": {
+            "session_id": "s1",
+            "resume_gateway_url": "url",
+            "application": {"id": "123"},
+            "user": {"id": "1"},
+        },
+    }
+
+    await gw._handle_dispatch(data)
+    await asyncio.sleep(0)
+    sync_mock.assert_not_called()


### PR DESCRIPTION
## Summary
- sync application commands after READY event by default
- add `sync_commands_on_ready` flag to `Client`
- unit tests for new behaviour

## Testing
- `black disagreement/client.py disagreement/gateway.py tests/test_auto_sync_commands.py`
- `pylint disagreement/client.py disagreement/gateway.py tests/test_auto_sync_commands.py --disable=all --enable=E,F`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e6cbea22c832396b7e9d68af001df