### PR TITLE
Add shard tracking to Guild model

### DIFF
--- a/disagreement/client.py
+++ b/disagreement/client.py
@@ -927,10 +927,11 @@ class Client:
         return role
 
     def parse_guild(self, data: Dict[str, Any]) -> "Guild":
-        """Parses guild data and returns a Guild object, updating cache."""
+        """Parses guild data and returns a :class:`Guild` object, updating cache."""
         from .models import Guild
 
-        guild = Guild(data, client_instance=self)
+        shard_id = data.get("shard_id")
+        guild = Guild(data, client_instance=self, shard_id=shard_id)
         self._guilds.set(guild.id, guild)
 
         presences = {p["user"]["id"]: p for p in data.get("presences", [])}

--- a/disagreement/gateway.py
+++ b/disagreement/gateway.py
@@ -338,6 +338,8 @@ class GatewayClient:
             self._client_instance._ready_event.set()
             logger.info("Client is now marked as ready.")
 
+            if isinstance(raw_event_d_payload, dict) and self._shard_id is not None:
+                raw_event_d_payload["shard_id"] = self._shard_id
             await self._dispatcher.dispatch(event_name, raw_event_d_payload)
         elif event_name == "GUILD_MEMBERS_CHUNK":
             if isinstance(raw_event_d_payload, dict):
@@ -388,6 +390,8 @@ class GatewayClient:
             event_data_to_dispatch = (
                 raw_event_d_payload if isinstance(raw_event_d_payload, dict) else {}
             )
+            if isinstance(event_data_to_dispatch, dict) and self._shard_id is not None:
+                event_data_to_dispatch["shard_id"] = self._shard_id
             await self._dispatcher.dispatch(event_name, event_data_to_dispatch)
             await self._dispatcher.dispatch(
                 "SHARD_RESUME", {"shard_id": self._shard_id}
@@ -398,6 +402,8 @@ class GatewayClient:
             event_data_to_dispatch = (
                 raw_event_d_payload if isinstance(raw_event_d_payload, dict) else {}
             )
+            if isinstance(event_data_to_dispatch, dict) and self._shard_id is not None:
+                event_data_to_dispatch["shard_id"] = self._shard_id
 
             await self._dispatcher.dispatch(event_name, event_data_to_dispatch)
         else:

--- a/tests/test_guild_shard_property.py
+++ b/tests/test_guild_shard_property.py
@@ -1,0 +1,56 @@
+import pytest
+from unittest.mock import Mock
+
+from disagreement.models import Guild
+from disagreement.enums import (
+    VerificationLevel,
+    MessageNotificationLevel,
+    ExplicitContentFilterLevel,
+    MFALevel,
+    GuildNSFWLevel,
+    PremiumTier,
+)
+
+
+class DummyShard:
+    def __init__(self, shard_id):
+        self.id = shard_id
+        self.count = 1
+        self.gateway = Mock()
+
+
+class DummyManager:
+    def __init__(self):
+        self.shards = [DummyShard(0)]
+
+
+class DummyClient:
+    pass
+
+
+def _guild_data():
+    return {
+        "id": "1",
+        "name": "g",
+        "owner_id": "1",
+        "afk_timeout": 60,
+        "verification_level": VerificationLevel.NONE.value,
+        "default_message_notifications": MessageNotificationLevel.ALL_MESSAGES.value,
+        "explicit_content_filter": ExplicitContentFilterLevel.DISABLED.value,
+        "roles": [],
+        "emojis": [],
+        "features": [],
+        "mfa_level": MFALevel.NONE.value,
+        "system_channel_flags": 0,
+        "premium_tier": PremiumTier.NONE.value,
+        "nsfw_level": GuildNSFWLevel.DEFAULT.value,
+        "shard_id": 0,
+    }
+
+
+def test_guild_shard_property():
+    client = DummyClient()
+    client._shard_manager = DummyManager()
+    guild = Guild(_guild_data(), client_instance=client, shard_id=0)
+    assert guild.shard_id == 0
+    assert guild.shard is client._shard_manager.shards[0]


### PR DESCRIPTION
## Summary
- track the shard ID when parsing guilds
- expose shard property on `Guild`
- attach shard ID to gateway dispatched events
- test guild shard property

## Testing
- `pylint disagreement tests/test_guild_shard_property.py --disable=all --enable=E,F`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e6cc1d8e08323b1ee79d06a4c56ed