### PR TITLE
Add client cog retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ intents = disagreement.GatewayIntent.default() | disagreement.GatewayIntent.MESS
 client = disagreement.Client(token=token, command_prefix="!", intents=intents, mention_replies=True)
 async def main() -> None:
     client.add_cog(Basics(client))
+    # Retrieve the cog later by name
+    basics = client.get_cog("Basics")
     await client.run()
 
 

--- a/disagreement/client.py
+++ b/disagreement/client.py
@@ -653,6 +653,11 @@ class Client:
             # For now, assuming name is sufficient for removal from the handler's flat list.
         return removed_cog
 
+    def get_cog(self, name: str) -> Optional[Cog]:
+        """Return a loaded cog by name if present."""
+
+        return self.command_handler.get_cog(name)
+
     def check(self, coro: Callable[["CommandContext"], Awaitable[bool]]):
         """
         A decorator that adds a global check to the bot.

--- a/disagreement/ext/commands/core.py
+++ b/disagreement/ext/commands/core.py
@@ -366,6 +366,11 @@ class CommandHandler:
     def get_command(self, name: str) -> Optional[Command]:
         return self.commands.get(name.lower())
 
+    def get_cog(self, name: str) -> Optional["Cog"]:
+        """Return a loaded cog by name if present."""
+
+        return self.cogs.get(name)
+
     def add_cog(self, cog_to_add: "Cog") -> None:
         from .cog import Cog
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -62,6 +62,8 @@ intents = GatewayIntent.default() | GatewayIntent.MESSAGE_CONTENT
 client = Client(token=token, command_prefix="!", intents=intents, mention_replies=True)
 async def main() -> None:
     client.add_cog(Basics(client))
+    # Retrieve the cog later by name
+    basics = client.get_cog("Basics")
     await client.run()
 
 

--- a/tests/test_get_cog.py
+++ b/tests/test_get_cog.py
@@ -1,0 +1,29 @@
+import asyncio
+import pytest
+
+from disagreement.client import Client
+from disagreement.ext import commands
+
+
+class DummyCog(commands.Cog):
+    def __init__(self, client: Client) -> None:
+        super().__init__(client)
+
+
+@pytest.mark.asyncio()
+async def test_command_handler_get_cog():
+    bot = object()
+    handler = commands.core.CommandHandler(client=bot, prefix="!")
+    cog = DummyCog(bot)  # type: ignore[arg-type]
+    handler.add_cog(cog)
+    await asyncio.sleep(0)  # allow any scheduled tasks to start
+    assert handler.get_cog("DummyCog") is cog
+
+
+@pytest.mark.asyncio()
+async def test_client_get_cog():
+    client = Client(token="t")
+    cog = DummyCog(client)
+    client.add_cog(cog)
+    await asyncio.sleep(0)
+    assert client.get_cog("DummyCog") is cog


### PR DESCRIPTION
## Summary
- support retrieving cogs from `CommandHandler`
- expose `Client.get_cog`
- document cog retrieval in README and intro docs
- test command handler and client cog retrieval

## Testing
- `pylint disagreement --disable=all --enable=E,F`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f3d51a1848323a7a9bfe66f199e8c