### PR TITLE
Add Guild.me helper property

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A Python library for interacting with the Discord API, with a focus on bot devel
 - Message component helpers
 - `Message.jump_url` property for quick links to messages
 - Built-in caching layer
+- `Guild.me` property to access the bot's member object
 - Experimental voice support
 - Helpful error handling utilities
 

--- a/disagreement/models.py
+++ b/disagreement/models.py
@@ -1284,6 +1284,15 @@ class Guild:
     def get_role(self, role_id: str) -> Optional[Role]:
         return next((role for role in self.roles if role.id == role_id), None)
 
+    @property
+    def me(self) -> Optional[Member]:
+        """The member object for the connected bot in this guild, if present."""
+
+        client_user = getattr(self._client, "user", None)
+        if not client_user:
+            return None
+        return self.get_member(client_user.id)
+
     def __repr__(self) -> str:
         return f"<Guild id='{self.id}' name='{self.name}'>"
 

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -13,6 +13,15 @@ if member:
     print(member.display_name)
 ```
 
+To access the bot's own member object, use the ``Guild.me`` property. It returns
+``None`` if the bot is not in the guild or its user data hasn't been loaded:
+
+```python
+bot_member = guild.me
+if bot_member:
+    print(bot_member.joined_at)
+```
+
 The cache can be cleared manually if needed:
 
 ```python


### PR DESCRIPTION
## Summary
- add `Guild.me` to easily access the bot's member object
- document `Guild.me` in caching docs and README

## Testing
- `pyright`
- `pylint disagreement/models.py --disable=all --enable=E,F`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f3d5404608323ae69e11eac36e63e