### PR TITLE
Add CommandHandler.get_context utility

### DIFF
--- a/disagreement/client.py
+++ b/disagreement/client.py
@@ -599,6 +599,11 @@ class Client:
             return
         await self.command_handler.process_commands(message)
 
+    async def get_context(self, message: "Message") -> Optional["CommandContext"]:
+        """Return a :class:`CommandContext` for ``message`` without executing the command."""
+
+        return await self.command_handler.get_context(message)
+
     # --- Command Framework Methods ---
 
     def add_cog(self, cog: Cog) -> None:

--- a/tests/test_client_context_manager.py
+++ b/tests/test_client_context_manager.py
@@ -1,6 +1,9 @@
 import asyncio
-import pytest
 from unittest.mock import AsyncMock
+
+import pytest
+
+# pylint: disable=no-member
 
 from disagreement.client import Client
 

--- a/tests/test_get_context.py
+++ b/tests/test_get_context.py
@@ -1,0 +1,59 @@
+import pytest
+
+from disagreement.client import Client
+from disagreement.ext.commands.core import Command, CommandHandler
+from disagreement.models import Message
+
+
+class DummyBot:
+    def __init__(self):
+        self.executed = False
+
+
+@pytest.mark.asyncio
+async def test_get_context_parses_without_execution():
+    bot = DummyBot()
+    handler = CommandHandler(client=bot, prefix="!")
+
+    async def foo(ctx, number: int, word: str):
+        bot.executed = True
+
+    handler.add_command(Command(foo, name="foo"))
+
+    msg_data = {
+        "id": "1",
+        "channel_id": "c",
+        "author": {"id": "2", "username": "u", "discriminator": "0001"},
+        "content": "!foo 1 bar",
+        "timestamp": "t",
+    }
+    msg = Message(msg_data, client_instance=bot)
+
+    ctx = await handler.get_context(msg)
+    assert ctx is not None
+    assert ctx.command.name == "foo"
+    assert ctx.args == [1, "bar"]
+    assert bot.executed is False
+
+
+@pytest.mark.asyncio
+async def test_client_get_context():
+    client = Client(token="t")
+
+    async def foo(ctx):
+        raise RuntimeError("should not run")
+
+    client.command_handler.add_command(Command(foo, name="foo"))
+
+    msg_data = {
+        "id": "1",
+        "channel_id": "c",
+        "author": {"id": "2", "username": "u", "discriminator": "0001"},
+        "content": "!foo",
+        "timestamp": "t",
+    }
+    msg = Message(msg_data, client_instance=client)
+
+    ctx = await client.get_context(msg)
+    assert ctx is not None
+    assert ctx.command.name == "foo"


### PR DESCRIPTION
## Summary
- add `CommandHandler.get_context` for parsing messages without executing
- expose `Client.get_context`
- test parsing via new methods
- quiet pylint false positives

## Testing
- `pylint --disable=all --enable=E,F disagreement tests`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f3d62489883239fd28db52ee519dc