### PR TITLE
Handle async teardown in extension loader

### DIFF
--- a/tests/test_extension_loader.py
+++ b/tests/test_extension_loader.py
@@ -38,6 +38,22 @@ def create_async_module(name):
     return called
 
 
+def create_async_teardown_module(name):
+    mod = types.ModuleType(name)
+    called = {"setup": False, "teardown": False}
+
+    def setup():
+        called["setup"] = True
+
+    async def teardown():
+        called["teardown"] = True
+
+    mod.setup = setup
+    mod.teardown = teardown
+    sys.modules[name] = mod
+    return called
+
+
 def test_load_and_unload_extension():
     called = create_dummy_module("dummy_ext")
 
@@ -100,4 +116,14 @@ def test_async_setup():
     assert called["setup"] is True
 
     loader.unload_extension("async_ext")
+    assert called["teardown"] is True
+
+
+def test_async_teardown():
+    called = create_async_teardown_module("async_teardown_ext")
+
+    loader.load_extension("async_teardown_ext")
+    assert called["setup"] is True
+
+    loader.unload_extension("async_teardown_ext")
     assert called["teardown"] is True


### PR DESCRIPTION
## Summary
- run teardown coroutines correctly when unloading extensions
- test async teardown support

## Testing
- `pylint --disable=all --enable=E,F disagreement/ext/loader.py tests/test_extension_loader.py`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f3d7881788323b88cc91c5f194a40