### PR TITLE
Add invite fetching

### DIFF
--- a/disagreement/client.py
+++ b/disagreement/client.py
@@ -1643,6 +1643,19 @@ class Client:
 
         await self._http.delete_invite(code)
 
+    async def fetch_invite(self, code: Snowflake) -> Optional["Invite"]:
+        """|coro| Fetch a single invite by code."""
+
+        if self._closed:
+            raise DisagreementException("Client is closed.")
+
+        try:
+            data = await self._http.get_invite(code)
+            return self.parse_invite(data)
+        except DisagreementException as e:
+            print(f"Failed to fetch invite {code}: {e}")
+            return None
+
     async def fetch_invites(self, channel_id: Snowflake) -> List["Invite"]:
         """|coro| Fetch all invites for a channel."""
 

--- a/disagreement/http.py
+++ b/disagreement/http.py
@@ -726,6 +726,11 @@ class HTTPClient:
 
         await self.request("DELETE", f"/invites/{code}")
 
+    async def get_invite(self, code: "Snowflake") -> Dict[str, Any]:
+        """Fetches a single invite by its code."""
+
+        return await self.request("GET", f"/invites/{code}")
+
     async def create_webhook(
         self, channel_id: "Snowflake", payload: Dict[str, Any]
     ) -> "Webhook":

--- a/tests/test_invite.py
+++ b/tests/test_invite.py
@@ -1,0 +1,31 @@
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from disagreement.http import HTTPClient
+from disagreement.client import Client
+from disagreement.models import Invite
+
+
+@pytest.mark.asyncio
+async def test_http_get_invite_calls_request():
+    http = HTTPClient(token="t")
+    http.request = AsyncMock(return_value={"code": "abc"})
+
+    result = await http.get_invite("abc")
+
+    http.request.assert_called_once_with("GET", "/invites/abc")
+    assert result == {"code": "abc"}
+
+
+@pytest.mark.asyncio
+async def test_client_fetch_invite_returns_invite():
+    http = SimpleNamespace(get_invite=AsyncMock(return_value={"code": "abc"}))
+    client = Client.__new__(Client)
+    client._http = http
+    client._closed = False
+
+    invite = await client.fetch_invite("abc")
+
+    http.get_invite.assert_awaited_once_with("abc")
+    assert isinstance(invite, Invite)


### PR DESCRIPTION
## Summary
- implement `HTTPClient.get_invite`
- add `Client.fetch_invite`
- test invite fetching logic

## Testing
- `pylint --disable=all --enable=E,F disagreement tests/test_invite.py`
- `pyright`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f661065148323af8954e525753139