### PR TITLE
Add datetime properties for messages

### DIFF
--- a/disagreement/models.py
+++ b/disagreement/models.py
@@ -3,6 +3,7 @@ Data models for Discord objects.
 """
 
 import asyncio
+import datetime
 import io
 import json
 import os
@@ -123,6 +124,7 @@ class Message:
         self.author: User = User(data["author"], client_instance)
         self.content: str = data["content"]
         self.timestamp: str = data["timestamp"]
+        self.edited_timestamp: Optional[str] = data.get("edited_timestamp")
         if data.get("components"):
             self.components: Optional[List[ActionRow]] = [
                 ActionRow.from_dict(c, client_instance)
@@ -153,6 +155,20 @@ class Message:
         pattern = re.compile(r"<@!?\d+>|<#\d+>|<@&\d+>")
         cleaned = pattern.sub("", self.content)
         return " ".join(cleaned.split())
+
+    @property
+    def created_at(self) -> datetime.datetime:
+        """Return message timestamp as a :class:`~datetime.datetime`."""
+
+        return datetime.datetime.fromisoformat(self.timestamp)
+
+    @property
+    def edited_at(self) -> Optional[datetime.datetime]:
+        """Return edited timestamp as :class:`~datetime.datetime` if present."""
+
+        if self.edited_timestamp is None:
+            return None
+        return datetime.datetime.fromisoformat(self.edited_timestamp)
 
     async def pin(self) -> None:
         """|coro|

--- a/tests/test_message_clean_content.py
+++ b/tests/test_message_clean_content.py
@@ -21,3 +21,19 @@ def test_clean_content_removes_mentions():
 def test_clean_content_no_mentions():
     msg = make_message("Just text")
     assert msg.clean_content == "Just text"
+
+
+def test_created_at_parses_timestamp():
+    ts = "2024-05-04T12:34:56+00:00"
+    msg = make_message("hi")
+    msg.timestamp = ts
+    assert msg.created_at.isoformat() == ts
+
+
+def test_edited_at_parses_timestamp_or_none():
+    ts = "2024-05-04T12:35:56+00:00"
+    msg = make_message("hi")
+    msg.timestamp = ts
+    assert msg.edited_at is None
+    msg.edited_timestamp = ts
+    assert msg.edited_at.isoformat() == ts


### PR DESCRIPTION
## Summary
- parse message timestamps as `datetime`
- test the new `created_at` and `edited_at` properties

## Testing
- `pylint --disable=all --enable=E,F disagreement/models.py tests/test_message_clean_content.py`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f66117ac08323a11ada4f1711d02b