### PR TITLE
Add guild_permissions property

### DIFF
--- a/disagreement/models.py
+++ b/disagreement/models.py
@@ -894,6 +894,33 @@ class Member(User):  # Member inherits from User
 
         return max(role_objects, key=lambda r: r.position)
 
+    @property
+    def guild_permissions(self) -> "Permissions":
+        """Return the member's guild-level permissions."""
+
+        if not self.guild_id or not self._client:
+            return Permissions(0)
+
+        guild = self._client.get_guild(self.guild_id)
+        if guild is None:
+            return Permissions(0)
+
+        base = Permissions(0)
+
+        everyone = guild.get_role(guild.id)
+        if everyone is not None:
+            base |= Permissions(int(everyone.permissions))
+
+        for rid in self.roles:
+            role = guild.get_role(rid)
+            if role is not None:
+                base |= Permissions(int(role.permissions))
+
+        if base & Permissions.ADMINISTRATOR:
+            return Permissions(~0)
+
+        return base
+
 
 class PartialEmoji:
     """Represents a partial emoji, often used in components or reactions.

--- a/tests/test_member.py
+++ b/tests/test_member.py
@@ -1,4 +1,21 @@
-from disagreement.models import Member
+import pytest  # pylint: disable=E0401
+
+from disagreement.client import Client
+from disagreement.enums import (
+    VerificationLevel,
+    MessageNotificationLevel,
+    ExplicitContentFilterLevel,
+    MFALevel,
+    GuildNSFWLevel,
+    PremiumTier,
+)
+from disagreement.models import Member, Guild, Role
+from disagreement.permissions import Permissions
+
+
+class DummyClient(Client):
+    def __init__(self):
+        super().__init__(token="test")
 
 
 def _make_member(member_id: str, username: str, nick: str | None):
@@ -12,6 +29,58 @@ def _make_member(member_id: str, username: str, nick: str | None):
     return Member(data, client_instance=None)
 
 
+def _base_guild(client: Client) -> Guild:
+    data = {
+        "id": "1",
+        "name": "g",
+        "owner_id": "1",
+        "afk_timeout": 60,
+        "verification_level": VerificationLevel.NONE.value,
+        "default_message_notifications": MessageNotificationLevel.ALL_MESSAGES.value,
+        "explicit_content_filter": ExplicitContentFilterLevel.DISABLED.value,
+        "roles": [],
+        "emojis": [],
+        "features": [],
+        "mfa_level": MFALevel.NONE.value,
+        "system_channel_flags": 0,
+        "premium_tier": PremiumTier.NONE.value,
+        "nsfw_level": GuildNSFWLevel.DEFAULT.value,
+    }
+    guild = Guild(data, client_instance=client)
+    client._guilds.set(guild.id, guild)
+    return guild
+
+
+def _role(guild: Guild, rid: str, perms: Permissions) -> Role:
+    role = Role(
+        {
+            "id": rid,
+            "name": f"r{rid}",
+            "color": 0,
+            "hoist": False,
+            "position": 0,
+            "permissions": str(int(perms)),
+            "managed": False,
+            "mentionable": False,
+        }
+    )
+    guild.roles.append(role)
+    return role
+
+
+def _member(guild: Guild, client: Client, *roles: Role) -> Member:
+    data = {
+        "user": {"id": "10", "username": "u", "discriminator": "0001"},
+        "joined_at": "t",
+        "roles": [r.id for r in roles] or [guild.id],
+    }
+    member = Member(data, client_instance=client)
+    member.guild_id = guild.id
+    member._client = client
+    guild._members.set(member.id, member)
+    return member
+
+
 def test_display_name_prefers_nick():
     member = _make_member("1", "u", "nickname")
     assert member.display_name == "nickname"
@@ -20,3 +89,25 @@ def test_display_name_prefers_nick():
 def test_display_name_falls_back_to_username():
     member = _make_member("2", "u2", None)
     assert member.display_name == "u2"
+
+
+def test_guild_permissions_from_roles():
+    client = DummyClient()
+    guild = _base_guild(client)
+    everyone = _role(guild, guild.id, Permissions.VIEW_CHANNEL)
+    mod = _role(guild, "2", Permissions.MANAGE_MESSAGES)
+    member = _member(guild, client, everyone, mod)
+
+    perms = member.guild_permissions
+    assert perms & Permissions.VIEW_CHANNEL
+    assert perms & Permissions.MANAGE_MESSAGES
+    assert not perms & Permissions.BAN_MEMBERS
+
+
+def test_guild_permissions_administrator_role_grants_all():
+    client = DummyClient()
+    guild = _base_guild(client)
+    admin = _role(guild, "2", Permissions.ADMINISTRATOR)
+    member = _member(guild, client, admin)
+
+    assert member.guild_permissions == Permissions(~0)


### PR DESCRIPTION
## Summary
- implement `Member.guild_permissions` to resolve guild permissions
- create helper functions in member tests
- test new property with typical roles and administrator role

## Testing
- `pyright`
- `pylint --disable=all --enable=E,F disagreement`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f661227608323842bf08d0a8bdb7a