### PR TITLE
Add VoiceState model and member voice property

### DIFF
--- a/disagreement/models.py
+++ b/disagreement/models.py
@@ -814,6 +814,7 @@ class Member(User):  # Member inherits from User
         self.communication_disabled_until: Optional[str] = data.get(
             "communication_disabled_until"
         )  # ISO8601 timestamp
+        self.voice_state = data.get("voice_state")
 
         # If 'user' object was present, ensure User attributes are from there
         if user_data:
@@ -893,6 +894,14 @@ class Member(User):  # Member inherits from User
             return None
 
         return max(role_objects, key=lambda r: r.position)
+
+    @property
+    def voice(self) -> Optional["VoiceState"]:
+        """Return the member's cached voice state as a :class:`VoiceState`."""
+
+        if self.voice_state is None:
+            return None
+        return VoiceState.from_dict(self.voice_state)
 
 
 class PartialEmoji:
@@ -2634,6 +2643,45 @@ class VoiceStateUpdate:
     def __repr__(self) -> str:
         return (
             f"<VoiceStateUpdate guild_id='{self.guild_id}' user_id='{self.user_id}' "
+            f"channel_id='{self.channel_id}'>"
+        )
+
+
+@dataclass
+class VoiceState:
+    """Represents a cached voice state for a member."""
+
+    guild_id: Optional[str]
+    channel_id: Optional[str]
+    user_id: Optional[str]
+    session_id: Optional[str]
+    deaf: bool = False
+    mute: bool = False
+    self_deaf: bool = False
+    self_mute: bool = False
+    self_stream: Optional[bool] = None
+    self_video: bool = False
+    suppress: bool = False
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "VoiceState":
+        return cls(
+            guild_id=data.get("guild_id"),
+            channel_id=data.get("channel_id"),
+            user_id=data.get("user_id"),
+            session_id=data.get("session_id"),
+            deaf=data.get("deaf", False),
+            mute=data.get("mute", False),
+            self_deaf=data.get("self_deaf", False),
+            self_mute=data.get("self_mute", False),
+            self_stream=data.get("self_stream"),
+            self_video=data.get("self_video", False),
+            suppress=data.get("suppress", False),
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"<VoiceState guild_id='{self.guild_id}' user_id='{self.user_id}' "
             f"channel_id='{self.channel_id}'>"
         )
 

--- a/tests/test_member_voice.py
+++ b/tests/test_member_voice.py
@@ -1,0 +1,36 @@
+from disagreement.models import Member, VoiceState
+
+
+def test_member_voice_dataclass():
+    data = {
+        "user": {"id": "1", "username": "u", "discriminator": "0001"},
+        "joined_at": "t",
+        "roles": [],
+        "voice_state": {
+            "guild_id": "g",
+            "channel_id": "c",
+            "user_id": "1",
+            "session_id": "s",
+            "deaf": False,
+            "mute": True,
+            "self_deaf": False,
+            "self_mute": False,
+            "self_video": False,
+            "suppress": False,
+        },
+    }
+    member = Member(data, client_instance=None)
+    voice = member.voice
+    assert isinstance(voice, VoiceState)
+    assert voice.channel_id == "c"
+    assert voice.mute is True
+
+
+def test_member_voice_none():
+    data = {
+        "user": {"id": "2", "username": "u2", "discriminator": "0001"},
+        "joined_at": "t",
+        "roles": [],
+    }
+    member = Member(data, client_instance=None)
+    assert member.voice is None


### PR DESCRIPTION
## Summary
- implement a `VoiceState` dataclass
- expose cached voice state on `Member.voice`
- parse `voice_state` field when hydrating members
- test voice state mapping on `Member`

## Testing
- `pyright`
- `pylint disagreement/models.py tests/test_member_voice.py --disable=all --enable=E,F`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f66140a6083238f4372c5d9fbc03e