### PR TITLE
Add TextChannel.create_invite

### DIFF
--- a/disagreement/http.py
+++ b/disagreement/http.py
@@ -721,6 +721,26 @@ class HTTPClient:
 
         return Invite.from_dict(data)
 
+    async def create_channel_invite(
+        self,
+        channel_id: "Snowflake",
+        payload: Dict[str, Any],
+        *,
+        reason: Optional[str] = None,
+    ) -> "Invite":
+        """Creates an invite for a channel with an optional audit log reason."""
+
+        headers = {"X-Audit-Log-Reason": reason} if reason else None
+        data = await self.request(
+            "POST",
+            f"/channels/{channel_id}/invites",
+            payload=payload,
+            custom_headers=headers,
+        )
+        from .models import Invite
+
+        return Invite.from_dict(data)
+
     async def delete_invite(self, code: str) -> None:
         """Deletes an invite by code."""
 

--- a/disagreement/models.py
+++ b/disagreement/models.py
@@ -1630,6 +1630,31 @@ class TextChannel(Channel, Messageable):
         data = await self._client._http.start_thread_without_message(self.id, payload)
         return cast("Thread", self._client.parse_channel(data))
 
+    async def create_invite(
+        self,
+        *,
+        max_age: Optional[int] = None,
+        max_uses: Optional[int] = None,
+        temporary: Optional[bool] = None,
+        unique: Optional[bool] = None,
+        reason: Optional[str] = None,
+    ) -> "Invite":
+        """|coro| Create an invite to this channel."""
+
+        payload: Dict[str, Any] = {}
+        if max_age is not None:
+            payload["max_age"] = max_age
+        if max_uses is not None:
+            payload["max_uses"] = max_uses
+        if temporary is not None:
+            payload["temporary"] = temporary
+        if unique is not None:
+            payload["unique"] = unique
+
+        return await self._client._http.create_channel_invite(
+            self.id, payload, reason=reason
+        )
+
 
 class VoiceChannel(Channel):
     """Represents a guild voice channel or stage voice channel."""

--- a/tests/test_invites.py
+++ b/tests/test_invites.py
@@ -1,0 +1,39 @@
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from disagreement.client import Client
+from disagreement.http import HTTPClient
+from disagreement.models import TextChannel, Invite
+
+
+@pytest.mark.asyncio
+async def test_create_channel_invite_calls_request_and_returns_model():
+    http = HTTPClient(token="t")
+    http.request = AsyncMock(return_value={"code": "abc"})
+    invite = await http.create_channel_invite("123", {"max_age": 60}, reason="r")
+
+    http.request.assert_called_once_with(
+        "POST",
+        "/channels/123/invites",
+        payload={"max_age": 60},
+        custom_headers={"X-Audit-Log-Reason": "r"},
+    )
+    assert isinstance(invite, Invite)
+
+
+@pytest.mark.asyncio
+async def test_textchannel_create_invite_uses_http():
+    http = SimpleNamespace(
+        create_channel_invite=AsyncMock(return_value=Invite.from_dict({"code": "a"}))
+    )
+    client = Client(token="t")
+    client._http = http
+
+    channel = TextChannel({"id": "c", "type": 0}, client)
+    invite = await channel.create_invite(max_age=30, reason="why")
+
+    http.create_channel_invite.assert_awaited_once_with(
+        "c", {"max_age": 30}, reason="why"
+    )
+    assert isinstance(invite, Invite)


### PR DESCRIPTION
## Summary
- add `HTTPClient.create_channel_invite` to support invite creation with reason header
- add `TextChannel.create_invite` helper method
- test invite creation at HTTP and model levels

## Testing
- `pyright`
- `pylint --disable=all --enable=E,F disagreement/http.py disagreement/models.py tests/test_invites.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f66147bd88323821682e559affb00