### PR TITLE
Add sequence utility helpers

### DIFF
--- a/disagreement/__init__.py
+++ b/disagreement/__init__.py
@@ -51,7 +51,7 @@ from .errors import (
     NotFound,
 )
 from .color import Color
-from .utils import utcnow, message_pager
+from .utils import utcnow, message_pager, get, find
 from .enums import (
     GatewayIntent,
     GatewayOpcode,
@@ -151,6 +151,8 @@ __all__ = [
     "Color",
     "utcnow",
     "message_pager",
+    "get",
+    "find",
     "GatewayIntent",
     "GatewayOpcode",
     "ButtonStyle",

--- a/disagreement/utils.py
+++ b/disagreement/utils.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Any, AsyncIterator, Dict, Optional, TYPE_CHECKING
+from typing import Any, AsyncIterator, Dict, Iterable, Optional, TYPE_CHECKING, Callable
 
 if TYPE_CHECKING:  # pragma: no cover - for type hinting only
     from .models import Message, TextChannel
@@ -12,6 +12,50 @@ if TYPE_CHECKING:  # pragma: no cover - for type hinting only
 def utcnow() -> datetime:
     """Return the current timezone-aware UTC time."""
     return datetime.now(timezone.utc)
+
+
+def find(predicate: Callable[[Any], bool], iterable: Iterable[Any]) -> Optional[Any]:
+    """Return the first element in ``iterable`` matching the ``predicate``.
+
+    Parameters
+    ----------
+    predicate:
+        A callable that returns ``True`` for a matching element.
+    iterable:
+        The iterable to search through.
+
+    Returns
+    -------
+    Any | None
+        The first element that matches, or ``None`` if no element does.
+    """
+
+    for element in iterable:
+        if predicate(element):
+            return element
+    return None
+
+
+def get(iterable: Iterable[Any], **attrs: Any) -> Optional[Any]:
+    """Return the first element with matching attributes.
+
+    Parameters
+    ----------
+    iterable:
+        The iterable to search through.
+    **attrs:
+        Attributes and values to match on.
+
+    Returns
+    -------
+    Any | None
+        The element with matching attributes, or ``None`` if not found.
+    """
+
+    def predicate(elem: Any) -> bool:
+        return all(getattr(elem, attr, None) == value for attr, value in attrs.items())
+
+    return find(predicate, iterable)
 
 
 async def message_pager(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,26 @@
 from datetime import timezone
 
-from disagreement.utils import utcnow
+from types import SimpleNamespace
+
+from disagreement.utils import utcnow, find, get
 
 
 def test_utcnow_timezone():
     now = utcnow()
     assert now.tzinfo == timezone.utc
+
+
+def test_find_returns_matching_element():
+    seq = [1, 2, 3]
+    assert find(lambda x: x > 1, seq) == 2
+    assert find(lambda x: x > 3, seq) is None
+
+
+def test_get_matches_attributes():
+    items = [
+        SimpleNamespace(id=1, name="a"),
+        SimpleNamespace(id=2, name="b"),
+    ]
+    assert get(items, id=2) is items[1]
+    assert get(items, id=1, name="a") is items[0]
+    assert get(items, name="c") is None


### PR DESCRIPTION
## Summary
- add `find` and `get` utilities
- export new utilities from package
- test `find` and `get`

## Testing
- `black disagreement/utils.py disagreement/__init__.py tests/test_utils.py`
- `pylint --disable=all --enable=E,F disagreement/utils.py disagreement/__init__.py tests/test_utils.py`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f6618380c83239a523c9e2bd56951