### PR TITLE
Add message crosspost helper

### DIFF
--- a/disagreement/http.py
+++ b/disagreement/http.py
@@ -663,6 +663,15 @@ class HTTPClient:
 
         await self.request("DELETE", f"/channels/{channel_id}/pins/{message_id}")
 
+    async def crosspost_message(
+        self, channel_id: "Snowflake", message_id: "Snowflake"
+    ) -> Dict[str, Any]:
+        """Crossposts a message to any following channels."""
+
+        return await self.request(
+            "POST", f"/channels/{channel_id}/messages/{message_id}/crosspost"
+        )
+
     async def delete_channel(
         self, channel_id: str, reason: Optional[str] = None
     ) -> None:

--- a/disagreement/models.py
+++ b/disagreement/models.py
@@ -180,6 +180,15 @@ class Message:
         await self._client._http.unpin_message(self.channel_id, self.id)
         self.pinned = False
 
+    async def crosspost(self) -> "Message":
+        """|coro|
+
+        Crossposts this message to all follower channels and return the resulting message.
+        """
+
+        data = await self._client._http.crosspost_message(self.channel_id, self.id)
+        return self._client.parse_message(data)
+
     async def reply(
         self,
         content: Optional[str] = None,

--- a/tests/test_crosspost_message.py
+++ b/tests/test_crosspost_message.py
@@ -1,0 +1,41 @@
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from disagreement.http import HTTPClient
+from disagreement.client import Client
+from disagreement.models import Message
+
+
+@pytest.mark.asyncio
+async def test_http_crosspost_message_calls_request():
+    http = HTTPClient(token="t")
+    http.request = AsyncMock(return_value={"id": "m"})
+    data = await http.crosspost_message("c", "m")
+    http.request.assert_called_once_with(
+        "POST",
+        "/channels/c/messages/m/crosspost",
+    )
+    assert data == {"id": "m"}
+
+
+@pytest.mark.asyncio
+async def test_message_crosspost_returns_message():
+    payload = {
+        "id": "2",
+        "channel_id": "1",
+        "author": {"id": "3", "username": "u", "discriminator": "0001"},
+        "content": "hi",
+        "timestamp": "t",
+    }
+    http = SimpleNamespace(crosspost_message=AsyncMock(return_value=payload))
+    client = Client.__new__(Client)
+    client._http = http
+    client.parse_message = lambda d: Message(d, client_instance=client)
+    message = Message(payload, client_instance=client)
+
+    new_msg = await message.crosspost()
+
+    http.crosspost_message.assert_awaited_once_with("1", "2")
+    assert isinstance(new_msg, Message)
+    assert new_msg._client is client


### PR DESCRIPTION
## Summary
- implement `HTTPClient.crosspost_message`
- expose `Message.crosspost` coroutine
- test the new helper and model method

## Testing
- `pylint --disable=all --enable=E,F disagreement tests/test_crosspost_message.py`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f661734608323a3818a024e61a55d