### PR TITLE
Implement snowflake_time helper

### DIFF
--- a/disagreement/__init__.py
+++ b/disagreement/__init__.py
@@ -51,7 +51,7 @@ from .errors import (
     NotFound,
 )
 from .color import Color
-from .utils import utcnow, message_pager
+from .utils import utcnow, message_pager, snowflake_time
 from .enums import (
     GatewayIntent,
     GatewayOpcode,
@@ -151,6 +151,7 @@ __all__ = [
     "Color",
     "utcnow",
     "message_pager",
+    "snowflake_time",
     "GatewayIntent",
     "GatewayOpcode",
     "ButtonStyle",

--- a/disagreement/utils.py
+++ b/disagreement/utils.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any, AsyncIterator, Dict, Optional, TYPE_CHECKING
 
+# Discord epoch in milliseconds (2015-01-01T00:00:00Z)
+DISCORD_EPOCH = 1420070400000
+
 if TYPE_CHECKING:  # pragma: no cover - for type hinting only
     from .models import Message, TextChannel
 
@@ -12,6 +15,24 @@ if TYPE_CHECKING:  # pragma: no cover - for type hinting only
 def utcnow() -> datetime:
     """Return the current timezone-aware UTC time."""
     return datetime.now(timezone.utc)
+
+
+def snowflake_time(snowflake: int) -> datetime:
+    """Return the creation time of a Discord snowflake.
+
+    Parameters
+    ----------
+    snowflake:
+        The snowflake ID to convert.
+
+    Returns
+    -------
+    datetime
+        The UTC timestamp embedded in the snowflake.
+    """
+
+    timestamp_ms = (snowflake >> 22) + DISCORD_EPOCH
+    return datetime.fromtimestamp(timestamp_ms / 1000, tz=timezone.utc)
 
 
 async def message_pager(

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -1,0 +1,20 @@
+# Utility Helpers
+
+Disagreement provides a few small utility functions for working with Discord data.
+
+## `utcnow`
+
+Returns the current timezone-aware UTC `datetime`.
+
+## `snowflake_time`
+
+Converts a Discord snowflake ID into the UTC timestamp when it was generated.
+
+```python
+from disagreement.utils import snowflake_time
+
+created_at = snowflake_time(175928847299117063)
+print(created_at.isoformat())
+```
+
+The function extracts the timestamp from the snowflake and returns a `datetime` in UTC.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,3 +63,4 @@ nav:
     - 'OAuth2': 'oauth2.md'
     - 'Presence': 'presence.md'
     - 'Voice Client': 'voice_client.md'
+    - 'Utility Helpers': 'utils.md'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,15 @@
-from datetime import timezone
+from datetime import datetime, timezone
 
-from disagreement.utils import utcnow
+from disagreement.utils import utcnow, snowflake_time
 
 
 def test_utcnow_timezone():
     now = utcnow()
     assert now.tzinfo == timezone.utc
+
+
+def test_snowflake_time():
+    dt = datetime(2020, 1, 1, tzinfo=timezone.utc)
+    ms = int(dt.timestamp() * 1000) - 1420070400000
+    snowflake = ms << 22
+    assert snowflake_time(snowflake) == dt


### PR DESCRIPTION
## Summary
- add `snowflake_time` to convert a Discord snowflake ID to a `datetime`
- export helper in `__init__`
- document utilities in new `docs/utils.md`
- expose utilities page in MkDocs config
- test timestamp conversion

## Testing
- `pylint --disable=all --enable=E,F disagreement/utils.py tests/test_utils.py`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f661a2da0832388a20c53574d0200