### PR TITLE
Implement runtime loop interval change

### DIFF
--- a/tests/test_tasks_extension.py
+++ b/tests/test_tasks_extension.py
@@ -82,3 +82,24 @@ async def test_before_after_loop_callbacks() -> None:
     await asyncio.sleep(0.01)
     assert events and events[0] == "before"
     assert "after" in events
+
+
+@pytest.mark.asyncio
+async def test_change_interval_and_current_loop() -> None:
+    count = 0
+
+    @tasks.loop(seconds=0.01)
+    async def ticker() -> None:
+        nonlocal count
+        count += 1
+
+    ticker.start()
+    await asyncio.sleep(0.03)
+    initial = ticker.current_loop
+    ticker.change_interval(seconds=0.02)
+    await asyncio.sleep(0.05)
+    ticker.stop()
+
+    assert initial >= 2
+    assert ticker.current_loop > initial
+    assert count == ticker.current_loop


### PR DESCRIPTION
## Summary
- add `change_interval` to tasks module
- track loop iterations via `current_loop`
- expose both features through `_Loop` and `_BoundLoop`
- test the new functionality

## Testing
- `pylint disagreement/ext/tasks.py tests/test_tasks_extension.py --disable=all --enable=E,F`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f661a5fe08323a730ae158a397624