### PR TITLE
Add Permissions.all convenience

### DIFF
--- a/disagreement/permissions.py
+++ b/disagreement/permissions.py
@@ -57,6 +57,15 @@ class Permissions(IntFlag):
     USE_EXTERNAL_SOUNDS = 1 << 45
     SEND_VOICE_MESSAGES = 1 << 46
 
+    @classmethod
+    def all(cls) -> "Permissions":
+        """Return a ``Permissions`` object with every permission bit enabled."""
+
+        value = 0
+        for perm in cls:
+            value |= perm.value
+        return cls(value)
+
 
 def permissions_value(*perms: Permissions | int | Iterable[Permissions | int]) -> int:
     """Return a combined integer value for multiple permissions."""

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -15,6 +15,12 @@ from disagreement import Permissions
 value = Permissions.SEND_MESSAGES | Permissions.MANAGE_MESSAGES
 ```
 
+You can also get a bitmask containing **every** permission:
+
+```python
+all_perms = Permissions.all()
+```
+
 ## Helper Functions
 
 ### ``permissions_value``

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -32,3 +32,11 @@ def test_missing_permissions():
         current, Permissions.SEND_MESSAGES, Permissions.MANAGE_MESSAGES
     )
     assert missing == [Permissions.MANAGE_MESSAGES]
+
+
+def test_permissions_all():
+    all_value = Permissions.all()
+    union = Permissions(0)
+    for perm in Permissions:
+        union |= perm
+    assert all_value == union


### PR DESCRIPTION
## Summary
- add `Permissions.all()` classmethod
- document `Permissions.all`
- test the new convenience

## Testing
- `black .`
- `pylint --disable=all --enable=E,F disagreement tests`
- `pyright`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f661ceecc8323a52dd68635f61f9a