### PR TITLE
Add Webhook.from_token helper

### DIFF
--- a/disagreement/http.py
+++ b/disagreement/http.py
@@ -753,6 +753,21 @@ class HTTPClient:
 
         await self.request("DELETE", f"/webhooks/{webhook_id}")
 
+    async def get_webhook(
+        self, webhook_id: "Snowflake", token: Optional[str] = None
+    ) -> "Webhook":
+        """Fetches a webhook by ID, optionally using its token."""
+
+        endpoint = f"/webhooks/{webhook_id}"
+        use_auth = True
+        if token is not None:
+            endpoint += f"/{token}"
+            use_auth = False
+        data = await self.request("GET", endpoint, use_auth_header=use_auth)
+        from .models import Webhook
+
+        return Webhook(data)
+
     async def execute_webhook(
         self,
         webhook_id: "Snowflake",

--- a/disagreement/models.py
+++ b/disagreement/models.py
@@ -1965,6 +1965,33 @@ class Webhook:
 
         return cls({"id": webhook_id, "token": token, "url": url})
 
+    @classmethod
+    def from_token(
+        cls,
+        webhook_id: str,
+        token: str,
+        session: Optional[aiohttp.ClientSession] = None,
+    ) -> "Webhook":
+        """Create a minimal :class:`Webhook` from an ID and token.
+
+        Parameters
+        ----------
+        webhook_id:
+            The ID of the webhook.
+        token:
+            The webhook token.
+        session:
+            Unused for now. Present for API compatibility.
+
+        Returns
+        -------
+        Webhook
+            A webhook instance containing only the ``id``, ``token`` and ``url``.
+        """
+
+        url = f"https://discord.com/api/webhooks/{webhook_id}/{token}"
+        return cls({"id": webhook_id, "token": token, "url": url})
+
     async def send(
         self,
         content: Optional[str] = None,

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -146,6 +146,16 @@ def test_webhook_from_url_parses_id_and_token():
     assert webhook.url == url
 
 
+def test_webhook_from_token_builds_url_and_fields():
+    from disagreement.models import Webhook
+
+    webhook = Webhook.from_token("123", "token")
+
+    assert webhook.id == "123"
+    assert webhook.token == "token"
+    assert webhook.url == "https://discord.com/api/webhooks/123/token"
+
+
 @pytest.mark.asyncio
 async def test_execute_webhook_calls_request():
     http = HTTPClient(token="t")


### PR DESCRIPTION
## Summary
- add `Webhook.from_token` to build minimal webhook objects
- implement `HTTPClient.get_webhook` for optional fetch logic
- test `Webhook.from_token`

## Testing
- `black disagreement tests`
- `pylint --disable=all --enable=E,F disagreement tests`
- `pyright`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f661b9cf08323ab1c073de31c9a5b