### PR TITLE
Implement VoiceClient pause/resume

### DIFF
--- a/docs/voice_features.md
+++ b/docs/voice_features.md
@@ -6,6 +6,10 @@ Disagreement includes experimental support for connecting to voice channels. You
 voice = await client.join_voice(guild_id, channel_id)
 await voice.play_file("welcome.mp3")
 await voice.play_file("another.mp3")  # switch sources while connected
+voice.pause()
+voice.resume()
+if voice.is_playing():
+    print("audio is playing")
 await voice.close()
 ```
 


### PR DESCRIPTION
## Summary
- add playback state tracking and pause/resume helpers
- document pause/resume use in `docs/voice_features.md`
- test new pause/resume behaviour

## Testing
- `pyright`
- `pylint --disable=all --enable=E,F disagreement tests | head -n 20`
- `pytest tests/test_voice_client.py tests/test_member_voice.py tests/test_webhooks.py::test_get_webhook_calls_request -q`

------
https://chatgpt.com/codex/tasks/task_e_684f799bcfcc8323a392415f7f372197