### PR TITLE
Implement Client logout method

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ These options are forwarded to ``HTTPClient`` when it creates the underlying
 ``aiohttp.ClientSession``. You can specify a custom ``connector`` or any other
 session parameter supported by ``aiohttp``.
 
+### Logging Out
+
+Call ``Client.logout`` to disconnect from the Gateway and clear the current bot token while keeping the HTTP session alive. Assign a new token and call ``connect`` or ``run`` to log back in.
+
 ### Default Allowed Mentions
 
 Specify default mention behaviour for all outgoing messages when constructing the client:

--- a/disagreement/client.py
+++ b/disagreement/client.py
@@ -423,6 +423,14 @@ class Client:
             self._gateway = None
         self._ready_event.clear()  # No longer ready if gateway is closed
 
+    async def logout(self) -> None:
+        """Invalidate the bot token and disconnect from the Gateway."""
+        await self.close_gateway()
+        self.token = ""
+        self._http.token = ""
+        self.user = None
+        self.start_time = None
+
     def is_closed(self) -> bool:
         """Indicates if the client has been closed."""
         return self._closed


### PR DESCRIPTION
## Summary
- introduce `Client.logout` to invalidate the token and only close the gateway
- document logging out in the README

## Testing
- `pyright`
- `pylint --disable=all --enable=E,F disagreement`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f799bc85483238656dcd3f8e8c397